### PR TITLE
Fix IFTTT pump webhook URL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ npm run check            # TypeScript/Svelte type checking
 - `GET /api/health` - Health check with IFTTT mode status
 - `POST /api/equipment/heater/on` - Trigger IFTTT `hot-tub-heat-on`
 - `POST /api/equipment/heater/off` - Trigger IFTTT `hot-tub-heat-off`
-- `POST /api/equipment/pump/run` - Trigger IFTTT `pump-run-2hr`
+- `POST /api/equipment/pump/run` - Trigger IFTTT `cycle_hot_tub_ionizer`
 
 ## Development Methodology: TDD Red/Green
 

--- a/PLAN-IFTTT-HARNESS.md
+++ b/PLAN-IFTTT-HARNESS.md
@@ -116,7 +116,7 @@ Based on archived implementation, these are the IFTTT events:
 |--------|-----------------|-------------|
 | Heater ON | `hot-tub-heat-on` | Starts pump → waits → activates heater |
 | Heater OFF | `hot-tub-heat-off` | Stops heater → pump cooling → stops pump |
-| Pump Run | `pump-run-2hr` | Runs pump for 2 hours (new event) |
+| Pump Run | `cycle_hot_tub_ionizer` | Runs pump for 2 hours |
 
 ## File Structure
 

--- a/backend/src/Controllers/EquipmentController.php
+++ b/backend/src/Controllers/EquipmentController.php
@@ -99,14 +99,14 @@ class EquipmentController
     /**
      * Run the pump for 2 hours.
      *
-     * Triggers the IFTTT pump-run-2hr event which
+     * Triggers the IFTTT cycle_hot_tub_ionizer event which
      * activates the circulation pump for 2 hours.
      */
     public function pumpRun(): array
     {
         $timestamp = date('c');
         $duration = 7200; // 2 hours in seconds
-        $success = $this->iftttClient->trigger('pump-run-2hr');
+        $success = $this->iftttClient->trigger('cycle_hot_tub_ionizer');
 
         $this->logger->log('pump_run', [
             'duration' => $duration,

--- a/backend/tests/ApiTest.php
+++ b/backend/tests/ApiTest.php
@@ -100,7 +100,7 @@ class ApiTest extends TestCase
         // Verify IFTTT was triggered
         rewind($this->consoleOutput);
         $consoleContents = stream_get_contents($this->consoleOutput);
-        $this->assertStringContainsString('pump-run-2hr', $consoleContents);
+        $this->assertStringContainsString('cycle_hot_tub_ionizer', $consoleContents);
     }
 
     public function testHeaterOnLogsToEventLog(): void

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,9 +6,10 @@ export default defineConfig({
 	plugins: [sveltekit(), tailwindcss()],
 	server: {
 		proxy: {
-			'/api': {
+			'/tub/backend/public/api': {
 				target: 'http://localhost:8080',
 				changeOrigin: true,
+				rewrite: (path) => path.replace(/^\/tub\/backend\/public/, ''),
 			},
 		},
 	},


### PR DESCRIPTION
## Summary
- Fixed pump command to use correct IFTTT webhook event (`cycle_hot_tub_ionizer` instead of non-existent `pump-run-2hr`)
- Fixed Vite dev server proxy to correctly handle `/tub/backend/public/api` paths

## Root cause
IFTTT silently accepts webhooks for non-existent event names (returns 200) but never executes them. The pump webhook was using a hallucinated event name that didn't match any configured applet.

## Test plan
- [x] UAT passed locally
- [x] PHPUnit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)