### PR TITLE
Add build info display in footer with commit link

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,7 +38,18 @@ jobs:
           cd frontend
           npm ci
 
+      - name: Generate build metadata
+        id: build_date
+        run: |
+          echo "date=$(date '+%b %d, %Y')" >> $GITHUB_OUTPUT
+          echo "sha_short=$(git rev-parse --short=7 HEAD)" >> $GITHUB_OUTPUT
+
       - name: Build frontend
+        env:
+          VITE_GIT_SHA: ${{ steps.build_date.outputs.sha_short }}
+          VITE_BUILD_NUMBER: ${{ github.run_number }}
+          VITE_BUILD_DATE: ${{ steps.build_date.outputs.date }}
+          VITE_GITHUB_REPO: ${{ github.repository }}
         run: |
           cd frontend
           npm run build

--- a/frontend/src/lib/config.ts
+++ b/frontend/src/lib/config.ts
@@ -17,6 +17,11 @@ function getEnvNumber(key: string, defaultValue: number): number {
 	return isNaN(parsed) ? defaultValue : parsed;
 }
 
+function getEnvString(key: string, defaultValue: string): string {
+	const value = import.meta.env[key];
+	return value === undefined || value === '' ? defaultValue : value;
+}
+
 export const schedulerConfig = {
 	/** Buffer time after scheduled execution to check status (default: 60 seconds) */
 	refreshBufferMs: getEnvNumber('VITE_REFRESH_BUFFER_MS', 60 * 1000),
@@ -26,4 +31,23 @@ export const schedulerConfig = {
 
 	/** Recheck interval for sliding window (default: 30 minutes) */
 	recheckIntervalMs: getEnvNumber('VITE_RECHECK_INTERVAL_MS', 30 * 60 * 1000),
+};
+
+/**
+ * Build information injected at build time via GitHub Actions.
+ * Shows "Local Dev" when running locally without env vars.
+ */
+export const buildInfo = {
+	gitSha: getEnvString('VITE_GIT_SHA', 'dev'),
+	buildNumber: getEnvString('VITE_BUILD_NUMBER', 'local'),
+	buildDate: getEnvString('VITE_BUILD_DATE', 'Local Dev'),
+	githubRepo: getEnvString('VITE_GITHUB_REPO', ''),
+	get version(): string {
+		if (this.gitSha === 'dev') return 'Local Dev';
+		return `${this.gitSha} (Build ${this.buildNumber}) • ${this.buildDate}`;
+	},
+	get commitUrl(): string | null {
+		if (this.gitSha === 'dev' || !this.githubRepo) return null;
+		return `https://github.com/${this.githubRepo}/commit/${this.gitSha}`;
+	}
 };

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import { api } from '$lib/api';
 	import { goto } from '$app/navigation';
 	import { base } from '$app/paths';
+	import { buildInfo } from '$lib/config';
 
 	let { data } = $props();
 
@@ -117,6 +118,18 @@
 			</div>
 		{:else}
 			<p class="text-slate-500 text-sm">Hold any button for help</p>
+		{/if}
+		{#if buildInfo.commitUrl}
+			<a
+				href={buildInfo.commitUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+				class="text-slate-600 hover:text-slate-400 text-xs mt-4 block"
+			>
+				{buildInfo.version}
+			</a>
+		{:else}
+			<p class="text-slate-600 text-xs mt-4">{buildInfo.version}</p>
 		{/if}
 	</footer>
 </div>


### PR DESCRIPTION
## Summary
- Generate build metadata (git SHA, build number, date) in GitHub Actions
- Display version info in footer with clickable link to commit
- Shows "Local Dev" when running locally without env vars

## Test plan
- [x] Deploy and verify version appears in footer
- [x] Verify link navigates to correct commit on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)