### PR TITLE
Add Healthchecks.io cron job monitoring

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,8 @@ jobs:
           JWT_EXPIRY_HOURS=${{ secrets.JWT_EXPIRY_HOURS }}
           WIRELESSTAG_OAUTH_TOKEN=${{ secrets.WIRELESSTAG_OAUTH_TOKEN }}
           WIRELESSTAG_DEVICE_ID=${{ secrets.WIRELESSTAG_DEVICE_ID }}
+          HEALTHCHECKS_IO_KEY=${{ secrets.HEALTHCHECKS_IO_KEY }}
+          HEALTHCHECKS_IO_CHANNEL=${{ secrets.HEALTHCHECKS_IO_CHANNEL }}
           EOF
 
       # Generate CRON_JWT for scheduled job authentication

--- a/backend/docs/healthchecks-io-poc-results.md
+++ b/backend/docs/healthchecks-io-poc-results.md
@@ -1,0 +1,118 @@
+# Healthchecks.io Proof of Concept Results
+
+**Date:** 2025-12-14
+**Status:** VERIFIED - Ready for Implementation
+
+## Key Findings
+
+### 1. State Machine Confirmed
+
+```
+new ──(first ping)──> up ──(timeout)──> grace ──(grace period)──> down
+                       ↑                                           │
+                       └───────────────(ping)──────────────────────┘
+```
+
+### 2. Never-Pinged Checks Do NOT Alert
+
+**Verified empirically:** A check created with 60s timeout + 60s grace, waited 150 seconds (2.5 minutes), remained in `new` state.
+
+This confirms the source code analysis - `alert_after` requires `last_ping` to exist.
+
+### 3. Timing Accuracy
+
+| Transition | Expected | Observed |
+|------------|----------|----------|
+| up → grace | 60s | 63s |
+| up → down | 120s | 126s |
+
+The timing is accurate within a few seconds of polling interval.
+
+### 4. API Response Times
+
+- Check creation: ~1-2s
+- Ping: <1s
+- Status poll: <1s
+
+## Required Architecture for Hot Tub Controller
+
+### For One-Off Jobs (user schedules "heat at 3pm")
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  WHEN USER SCHEDULES JOB (in PHP SchedulerService)              │
+├─────────────────────────────────────────────────────────────────┤
+│  1. Create cron entry                                            │
+│  2. Create Healthchecks.io check:                                │
+│     - timeout = (scheduled_time - now) + grace_buffer           │
+│     - grace = 30 minutes                                         │
+│  3. PING immediately (transitions new → up, ARMS the check)     │
+│  4. Store check UUID in job file                                │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  WHEN CRON EXECUTES (in cron-runner.sh)                         │
+├─────────────────────────────────────────────────────────────────┤
+│  SUCCESS PATH:                                                   │
+│    1. Execute API call                                           │
+│    2. If HTTP 200: DELETE the Healthchecks.io check             │
+│    3. Clean up job file                                          │
+│                                                                  │
+│  FAILURE PATH:                                                   │
+│    1. Execute API call                                           │
+│    2. If HTTP error: do NOT delete check                        │
+│    3. Check will timeout → grace → down → EMAIL ALERT           │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### API Calls Per Job
+
+| Scenario | Calls |
+|----------|-------|
+| Success | 3 (create, ping, delete) |
+| Cron never fires | 2 (create, ping, then timeout → alert) |
+| Cron fires but API fails | 2 (create, ping, then timeout → alert) |
+
+### For Recurring Jobs (optional future feature)
+
+```php
+// Create once with cron schedule
+$check = createCheck([
+    'name' => "recurring-heat-6am",
+    'schedule' => '0 6 * * *',
+    'tz' => 'America/New_York',
+    'grace' => 1800  // 30 min
+]);
+
+// Ping immediately to arm
+ping($check['ping_url']);
+
+// Job pings on each successful execution
+// Check alerts if any scheduled run is missed
+```
+
+## Free Tier Limits
+
+- 20 checks (concurrent)
+- Unlimited pings
+- Email, SMS (5 credits), webhooks
+- 100 log entries per check
+
+For the hot tub controller with ~5 max concurrent scheduled jobs, this is ample.
+
+## Test Results
+
+```
+✔ New check starts in new state
+✔ Check transitions to up after first ping
+✔ Check goes to grace and down after timeout (waited 2+ min)
+✔ Never pinged check does not alert (waited 2.5 min)
+```
+
+## Next Steps
+
+1. Create `HealthchecksClient` service class
+2. Integrate into `SchedulerService::scheduleJob()`
+3. Integrate into `cron-runner.sh` for deletion on success
+4. Add integration tests

--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -17,6 +17,7 @@ use HotTub\Services\UserRepositoryFactory;
 use HotTub\Services\SchedulerService;
 use HotTub\Services\CrontabAdapter;
 use HotTub\Services\CrontabBackupService;
+use HotTub\Services\HealthchecksClientFactory;
 use HotTub\Services\RequestLogger;
 use HotTub\Middleware\AuthMiddleware;
 use HotTub\Middleware\CorsMiddleware;
@@ -101,11 +102,17 @@ $apiBaseUrl = $protocol . '://' . $host . $scriptDir;
 $crontabBackupService = new CrontabBackupService($crontabBackupDir);
 $crontabAdapter = new CrontabAdapter($crontabBackupService);
 
+// Create Healthchecks.io client for job monitoring (feature flag: disabled if no API key)
+$healthchecksFactory = new HealthchecksClientFactory($config);
+$healthchecksClient = $healthchecksFactory->create();
+
 $schedulerService = new SchedulerService(
     $jobsDir,
     $cronRunnerPath,
     $apiBaseUrl,
-    $crontabAdapter
+    $crontabAdapter,
+    null, // TimeConverter (use default)
+    $healthchecksClient
 );
 $scheduleController = new ScheduleController($schedulerService);
 

--- a/backend/src/Contracts/HealthchecksClientInterface.php
+++ b/backend/src/Contracts/HealthchecksClientInterface.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Contracts;
+
+/**
+ * Contract for Healthchecks.io monitoring clients.
+ *
+ * This interface supports a "feature flag" pattern where the monitoring
+ * can be silently disabled when no API key is configured.
+ *
+ * Implementations:
+ * - HealthchecksClient: Real API calls to Healthchecks.io
+ * - NullHealthchecksClient: No-op implementation when monitoring is disabled
+ */
+interface HealthchecksClientInterface
+{
+    /**
+     * Check if monitoring is enabled.
+     *
+     * @return bool True if API calls will be made, false if disabled
+     */
+    public function isEnabled(): bool;
+
+    /**
+     * Create a new health check.
+     *
+     * @param string $name Human-readable name for the check
+     * @param int $timeout Seconds until check is considered late
+     * @param int $grace Additional seconds before alerting
+     * @param string|null $channels Channel UUID(s) to notify, or null for default
+     * @return array{uuid: string, ping_url: string}|null Check data or null if disabled/failed
+     */
+    public function createCheck(string $name, int $timeout, int $grace, ?string $channels = null): ?array;
+
+    /**
+     * Ping a health check to signal it's alive.
+     *
+     * @param string $pingUrl The ping URL returned from createCheck
+     * @return bool True on success, false on failure
+     */
+    public function ping(string $pingUrl): bool;
+
+    /**
+     * Delete a health check.
+     *
+     * @param string $uuid The check UUID
+     * @return bool True on success, false on failure
+     */
+    public function delete(string $uuid): bool;
+
+    /**
+     * Get a health check's current status.
+     *
+     * @param string $uuid The check UUID
+     * @return array{uuid: string, status: string, n_pings: int}|null Check data or null if not found
+     */
+    public function getCheck(string $uuid): ?array;
+}

--- a/backend/src/Services/HealthchecksClient.php
+++ b/backend/src/Services/HealthchecksClient.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Services;
+
+use HotTub\Contracts\HealthchecksClientInterface;
+
+/**
+ * Real Healthchecks.io client that makes API calls.
+ *
+ * Error Handling Philosophy:
+ * - API errors are logged but DO NOT throw exceptions
+ * - The application continues functioning even if monitoring fails
+ * - Invalid API keys result in logged warnings, not crashes
+ *
+ * This is intentional: monitoring failure should not prevent
+ * the hot tub controller from functioning.
+ */
+class HealthchecksClient implements HealthchecksClientInterface
+{
+    private const API_BASE_URL = 'https://healthchecks.io/api/v3';
+
+    private string $apiKey;
+    private ?string $defaultChannel;
+    private ?string $logFile;
+
+    public function __construct(
+        string $apiKey,
+        ?string $defaultChannel = null,
+        ?string $logFile = null
+    ) {
+        $this->apiKey = $apiKey;
+        $this->defaultChannel = $defaultChannel;
+        $this->logFile = $logFile;
+    }
+
+    public function isEnabled(): bool
+    {
+        return true;
+    }
+
+    public function createCheck(string $name, int $timeout, int $grace, ?string $channels = null): ?array
+    {
+        $payload = [
+            'name' => $name,
+            'timeout' => $timeout,
+            'grace' => $grace,
+        ];
+
+        // Add channels if specified or use default
+        $channelId = $channels ?? $this->defaultChannel;
+        if ($channelId !== null) {
+            $payload['channels'] = $channelId;
+        }
+
+        $response = $this->apiRequest('POST', '/checks/', $payload);
+
+        if ($response === null) {
+            return null;
+        }
+
+        // Return the essential fields
+        return [
+            'uuid' => $response['uuid'] ?? null,
+            'ping_url' => $response['ping_url'] ?? null,
+            'status' => $response['status'] ?? null,
+        ];
+    }
+
+    public function ping(string $pingUrl): bool
+    {
+        // Ping URLs go directly to hc-ping.com, not the API
+        $ch = curl_init($pingUrl);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 10,
+            CURLOPT_CONNECTTIMEOUT => 5,
+        ]);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $error = curl_error($ch);
+        curl_close($ch);
+
+        if ($httpCode !== 200) {
+            $this->log('warning', 'Healthchecks ping failed', [
+                'ping_url' => $pingUrl,
+                'http_code' => $httpCode,
+                'error' => $error,
+            ]);
+            return false;
+        }
+
+        return true;
+    }
+
+    public function delete(string $uuid): bool
+    {
+        $response = $this->apiRequest('DELETE', '/checks/' . $uuid);
+
+        // DELETE returns the check data on success, null on failure
+        return $response !== null;
+    }
+
+    public function getCheck(string $uuid): ?array
+    {
+        $response = $this->apiRequest('GET', '/checks/' . $uuid);
+
+        if ($response === null) {
+            return null;
+        }
+
+        return [
+            'uuid' => $response['uuid'] ?? null,
+            'status' => $response['status'] ?? null,
+            'n_pings' => $response['n_pings'] ?? 0,
+            'last_ping' => $response['last_ping'] ?? null,
+        ];
+    }
+
+    /**
+     * Make an API request to Healthchecks.io.
+     *
+     * @param string $method HTTP method (GET, POST, DELETE)
+     * @param string $endpoint API endpoint path
+     * @param array|null $payload Request body for POST requests
+     * @return array|null Decoded response or null on failure
+     */
+    private function apiRequest(string $method, string $endpoint, ?array $payload = null): ?array
+    {
+        $url = self::API_BASE_URL . $endpoint;
+
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT => 30,
+            CURLOPT_CONNECTTIMEOUT => 10,
+            CURLOPT_HTTPHEADER => [
+                'X-Api-Key: ' . $this->apiKey,
+                'Content-Type: application/json',
+            ],
+        ]);
+
+        if ($method === 'POST') {
+            curl_setopt($ch, CURLOPT_POST, true);
+            if ($payload !== null) {
+                curl_setopt($ch, CURLOPT_POSTFIELDS, json_encode($payload));
+            }
+        } elseif ($method === 'DELETE') {
+            curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+        }
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        $error = curl_error($ch);
+        curl_close($ch);
+
+        // Check for curl errors
+        if ($response === false) {
+            $this->log('error', 'Healthchecks API curl error', [
+                'method' => $method,
+                'endpoint' => $endpoint,
+                'error' => $error,
+            ]);
+            return null;
+        }
+
+        // Check for HTTP errors
+        if ($httpCode < 200 || $httpCode >= 300) {
+            $level = $httpCode === 401 ? 'warning' : 'error';
+            $this->log($level, 'Healthchecks API error', [
+                'method' => $method,
+                'endpoint' => $endpoint,
+                'http_code' => $httpCode,
+                'response' => $response,
+            ]);
+            return null;
+        }
+
+        // Decode JSON response
+        $data = json_decode($response, true);
+        if ($data === null && json_last_error() !== JSON_ERROR_NONE) {
+            $this->log('error', 'Healthchecks API invalid JSON', [
+                'method' => $method,
+                'endpoint' => $endpoint,
+                'response' => substr($response, 0, 200),
+            ]);
+            return null;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Log a message to the configured log file.
+     *
+     * @param string $level Log level (error, warning, info)
+     * @param string $message Log message
+     * @param array $context Additional context data
+     */
+    private function log(string $level, string $message, array $context = []): void
+    {
+        if ($this->logFile === null) {
+            return;
+        }
+
+        $logDir = dirname($this->logFile);
+        if (!is_dir($logDir)) {
+            @mkdir($logDir, 0755, true);
+        }
+
+        $entry = [
+            'timestamp' => date('c'),
+            'level' => strtoupper($level),
+            'message' => $message,
+            'context' => $context,
+        ];
+
+        @file_put_contents(
+            $this->logFile,
+            json_encode($entry, JSON_UNESCAPED_SLASHES) . "\n",
+            FILE_APPEND | LOCK_EX
+        );
+    }
+}

--- a/backend/src/Services/HealthchecksClientFactory.php
+++ b/backend/src/Services/HealthchecksClientFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Services;
+
+use HotTub\Contracts\HealthchecksClientInterface;
+
+/**
+ * Factory for creating Healthchecks.io clients.
+ *
+ * Feature Flag Behavior:
+ * - If HEALTHCHECKS_IO_KEY is not set or empty: returns NullHealthchecksClient
+ * - If HEALTHCHECKS_IO_KEY is set: returns HealthchecksClient
+ *
+ * This allows monitoring to be completely optional - the application
+ * works identically whether monitoring is enabled or not.
+ */
+class HealthchecksClientFactory
+{
+    /** @var array<string, string|null> */
+    private array $config;
+
+    /**
+     * @param array<string, string|null> $config Environment configuration
+     */
+    public function __construct(array $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Create a Healthchecks.io client based on configuration.
+     *
+     * @return HealthchecksClientInterface
+     */
+    public function create(): HealthchecksClientInterface
+    {
+        $apiKey = $this->config['HEALTHCHECKS_IO_KEY'] ?? null;
+
+        // Feature flag: if no API key, return null client
+        if (empty($apiKey)) {
+            return new NullHealthchecksClient();
+        }
+
+        // Get optional channel ID for notifications
+        $channelId = $this->config['HEALTHCHECKS_IO_CHANNEL'] ?? null;
+
+        // Get log file path (default to storage/logs)
+        $logFile = $this->config['HEALTHCHECKS_LOG_FILE']
+            ?? dirname(__DIR__, 2) . '/storage/logs/healthchecks.log';
+
+        return new HealthchecksClient($apiKey, $channelId, $logFile);
+    }
+}

--- a/backend/src/Services/NullHealthchecksClient.php
+++ b/backend/src/Services/NullHealthchecksClient.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Services;
+
+use HotTub\Contracts\HealthchecksClientInterface;
+
+/**
+ * No-op Healthchecks.io client for when monitoring is disabled.
+ *
+ * This client is used when:
+ * - No API key is configured (feature flag disabled)
+ * - The user explicitly disables monitoring
+ *
+ * All operations silently succeed without making any API calls.
+ */
+class NullHealthchecksClient implements HealthchecksClientInterface
+{
+    public function isEnabled(): bool
+    {
+        return false;
+    }
+
+    public function createCheck(string $name, int $timeout, int $grace, ?string $channels = null): ?array
+    {
+        return null;
+    }
+
+    public function ping(string $pingUrl): bool
+    {
+        return true;
+    }
+
+    public function delete(string $uuid): bool
+    {
+        return true;
+    }
+
+    public function getCheck(string $uuid): ?array
+    {
+        return null;
+    }
+}

--- a/backend/tests/Integration/Services/HealthchecksClientLiveTest.php
+++ b/backend/tests/Integration/Services/HealthchecksClientLiveTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Tests\Integration\Services;
+
+use HotTub\Services\HealthchecksClient;
+use HotTub\Services\HealthchecksClientFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Live API integration tests for Healthchecks.io client.
+ *
+ * These tests make real API calls to Healthchecks.io and verify
+ * the full workflow: create → ping → get status → delete.
+ *
+ * @group live
+ * @group healthchecks
+ */
+class HealthchecksClientLiveTest extends TestCase
+{
+    private ?HealthchecksClient $client = null;
+    private array $createdChecks = [];
+
+    protected function setUp(): void
+    {
+        // Load API key from env.production config
+        $envFile = dirname(__DIR__, 3) . '/config/env.production';
+        $config = [];
+
+        if (file_exists($envFile)) {
+            $content = file_get_contents($envFile);
+            foreach (explode("\n", $content) as $line) {
+                if (preg_match('/^([A-Z_]+)=(.*)$/', $line, $matches)) {
+                    $config[$matches[1]] = trim($matches[2]);
+                }
+            }
+        }
+
+        $apiKey = $config['HEALTHCHECKS_IO_KEY'] ?? getenv('HEALTHCHECKS_IO_KEY') ?: null;
+
+        if (empty($apiKey)) {
+            $this->markTestSkipped('HEALTHCHECKS_IO_KEY not configured');
+        }
+
+        // Get the "Down only checks" channel
+        $channelId = $config['HEALTHCHECKS_IO_CHANNEL'] ?? '9d1e9a48-1c1c-4a45-8c50-6705175ba58a';
+
+        $this->client = new HealthchecksClient(
+            $apiKey,
+            $channelId,
+            '/tmp/healthchecks-test.log'
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up any checks we created
+        if ($this->client !== null) {
+            foreach ($this->createdChecks as $uuid) {
+                $this->client->delete($uuid);
+            }
+        }
+    }
+
+    public function testCreateCheckReturnsUuidAndPingUrl(): void
+    {
+        $result = $this->client->createCheck(
+            'live-test-' . time(),
+            60,  // 1 minute timeout
+            60   // 1 minute grace
+        );
+
+        $this->assertNotNull($result, 'createCheck should return result');
+        $this->assertArrayHasKey('uuid', $result);
+        $this->assertArrayHasKey('ping_url', $result);
+        $this->assertNotEmpty($result['uuid']);
+        $this->assertStringContainsString('hc-ping.com', $result['ping_url']);
+
+        $this->createdChecks[] = $result['uuid'];
+    }
+
+    public function testNewCheckHasNewStatus(): void
+    {
+        $created = $this->client->createCheck(
+            'live-test-status-' . time(),
+            60,
+            60
+        );
+        $this->createdChecks[] = $created['uuid'];
+
+        $check = $this->client->getCheck($created['uuid']);
+
+        $this->assertNotNull($check);
+        $this->assertEquals('new', $check['status']);
+        $this->assertEquals(0, $check['n_pings']);
+    }
+
+    public function testPingTransitionsCheckToUp(): void
+    {
+        $created = $this->client->createCheck(
+            'live-test-ping-' . time(),
+            60,
+            60
+        );
+        $this->createdChecks[] = $created['uuid'];
+
+        // Ping the check
+        $pingResult = $this->client->ping($created['ping_url']);
+        $this->assertTrue($pingResult, 'Ping should succeed');
+
+        // Wait a moment for API to process
+        sleep(2);
+
+        // Verify status changed
+        $check = $this->client->getCheck($created['uuid']);
+        $this->assertEquals('up', $check['status']);
+        $this->assertEquals(1, $check['n_pings']);
+    }
+
+    public function testDeleteRemovesCheck(): void
+    {
+        $created = $this->client->createCheck(
+            'live-test-delete-' . time(),
+            60,
+            60
+        );
+
+        // Delete the check
+        $deleteResult = $this->client->delete($created['uuid']);
+        $this->assertTrue($deleteResult, 'Delete should succeed');
+
+        // Verify it's gone
+        $check = $this->client->getCheck($created['uuid']);
+        $this->assertNull($check, 'Deleted check should not be found');
+    }
+
+    public function testInvalidApiKeyLogsWarning(): void
+    {
+        $logFile = '/tmp/healthchecks-invalid-key-test.log';
+        @unlink($logFile);
+
+        $badClient = new HealthchecksClient(
+            'invalid-api-key-12345',
+            null,
+            $logFile
+        );
+
+        // This should fail but not throw
+        $result = $badClient->createCheck('test', 60, 60);
+
+        $this->assertNull($result, 'Should return null on auth failure');
+
+        // Verify warning was logged
+        $this->assertFileExists($logFile);
+        $log = file_get_contents($logFile);
+        $this->assertStringContainsString('WARNING', $log);
+        $this->assertStringContainsString('401', $log);
+
+        @unlink($logFile);
+    }
+
+    public function testFullWorkflowCreatePingDelete(): void
+    {
+        // This simulates what the scheduler will do:
+        // 1. Create check when job is scheduled
+        // 2. Ping immediately to arm it
+        // 3. Delete when job executes successfully
+
+        // Step 1: Create check
+        $checkName = 'workflow-test-' . time();
+        $created = $this->client->createCheck($checkName, 300, 60);
+
+        $this->assertNotNull($created);
+        $uuid = $created['uuid'];
+        // Don't add to createdChecks - we'll delete manually
+
+        // Step 2: Ping to arm
+        $pingResult = $this->client->ping($created['ping_url']);
+        $this->assertTrue($pingResult);
+
+        // Wait for API to process
+        sleep(2);
+
+        // Verify armed
+        $check = $this->client->getCheck($uuid);
+        $this->assertEquals('up', $check['status']);
+
+        // Step 3: Delete on "success"
+        $deleteResult = $this->client->delete($uuid);
+        $this->assertTrue($deleteResult);
+
+        // Verify gone
+        $check = $this->client->getCheck($uuid);
+        $this->assertNull($check);
+    }
+
+    /**
+     * Test that a check with channel attached can be created.
+     * This verifies our email alerting will work.
+     */
+    public function testCreateCheckWithChannelAttached(): void
+    {
+        $created = $this->client->createCheck(
+            'channel-test-' . time(),
+            60,
+            60
+        );
+        $this->createdChecks[] = $created['uuid'];
+
+        $this->assertNotNull($created);
+
+        // The client was constructed with a default channel,
+        // so the check should have it attached
+        // We can't easily verify this via API without a raw GET,
+        // but if the create succeeded, the channel was valid
+    }
+}

--- a/backend/tests/Poc/HealthchecksIoTest.php
+++ b/backend/tests/Poc/HealthchecksIoTest.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Proof-of-Concept Tests for Healthchecks.io Integration
+ *
+ * These tests verify our understanding of how Healthchecks.io behaves:
+ * 1. Does a newly created check alert if never pinged?
+ * 2. Does a check that's been pinged once then abandoned go to "down"?
+ * 3. How long do state transitions take?
+ *
+ * Run with: ./vendor/bin/phpunit tests/Poc/HealthchecksIoTest.php
+ *
+ * @group poc
+ * @group healthchecks
+ */
+
+namespace HotTub\Tests\Poc;
+
+use PHPUnit\Framework\TestCase;
+
+class HealthchecksIoTest extends TestCase
+{
+    private string $apiKey;
+    private string $baseUrl = 'https://healthchecks.io/api/v3';
+
+    // Store created check UUIDs for cleanup
+    private array $createdChecks = [];
+
+    protected function setUp(): void
+    {
+        // Load from env.production or environment
+        $envFile = dirname(__DIR__, 2) . '/config/env.production';
+        if (file_exists($envFile)) {
+            $content = file_get_contents($envFile);
+            if (preg_match('/^HEALTHCHECKS_IO_KEY=(.+)$/m', $content, $matches)) {
+                $this->apiKey = trim($matches[1]);
+            }
+        }
+
+        if (empty($this->apiKey)) {
+            $this->apiKey = getenv('HEALTHCHECKS_IO_KEY') ?: '';
+        }
+
+        if (empty($this->apiKey)) {
+            $this->markTestSkipped('HEALTHCHECKS_IO_KEY not configured');
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up any checks we created
+        foreach ($this->createdChecks as $uuid) {
+            $this->deleteCheck($uuid);
+        }
+    }
+
+    /**
+     * Test 1: Create a check and immediately check its status.
+     * Expected: status = "new" (never been pinged)
+     */
+    public function testNewCheckStartsInNewState(): void
+    {
+        $check = $this->createCheck([
+            'name' => 'poc-test-new-state-' . time(),
+            'timeout' => 60,  // 1 minute timeout
+            'grace' => 60,    // 1 minute grace
+        ]);
+
+        $this->assertNotNull($check, 'Check creation failed');
+        $this->createdChecks[] = $check['uuid'];
+
+        echo "\n  Created check: {$check['uuid']}\n";
+        echo "  Status: {$check['status']}\n";
+        echo "  Ping URL: {$check['ping_url']}\n";
+
+        $this->assertEquals('new', $check['status'], 'New check should start in "new" state');
+    }
+
+    /**
+     * Test 2: Create a check, ping it once, then check status.
+     * Expected: status = "up" after first ping
+     */
+    public function testCheckTransitionsToUpAfterFirstPing(): void
+    {
+        $check = $this->createCheck([
+            'name' => 'poc-test-ping-up-' . time(),
+            'timeout' => 60,
+            'grace' => 60,
+        ]);
+
+        $this->assertNotNull($check);
+        $this->createdChecks[] = $check['uuid'];
+
+        echo "\n  Created check: {$check['uuid']}, status: {$check['status']}\n";
+
+        // Ping to arm
+        $pingResult = $this->ping($check['ping_url']);
+        echo "  Pinged, response: $pingResult\n";
+
+        // Check status after ping
+        sleep(2); // Small delay for API to update
+        $updated = $this->getCheck($check['uuid']);
+
+        echo "  Status after ping: {$updated['status']}\n";
+        echo "  n_pings: {$updated['n_pings']}\n";
+
+        $this->assertEquals('up', $updated['status'], 'Check should be "up" after first ping');
+        $this->assertEquals(1, $updated['n_pings'], 'Should have 1 ping recorded');
+    }
+
+    /**
+     * Test 3: Create check with very short timeout, ping once, wait for timeout.
+     * This is the KEY test - does it transition to "grace" then "down"?
+     *
+     * Using minimum values: 60s timeout + 60s grace = 2 minutes total wait
+     */
+    public function testCheckGoesToGraceAndDownAfterTimeout(): void
+    {
+        // Use minimum allowed values for faster testing
+        $timeout = 60;  // 1 minute
+        $grace = 60;    // 1 minute
+
+        $check = $this->createCheck([
+            'name' => 'poc-test-timeout-' . time(),
+            'timeout' => $timeout,
+            'grace' => $grace,
+        ]);
+
+        $this->assertNotNull($check);
+        $this->createdChecks[] = $check['uuid'];
+
+        echo "\n  Created check: {$check['uuid']}\n";
+        echo "  Timeout: {$timeout}s, Grace: {$grace}s\n";
+        echo "  Initial status: {$check['status']}\n";
+
+        // PING ONCE to arm it
+        $pingResult = $this->ping($check['ping_url']);
+        echo "  Armed with ping: $pingResult\n";
+
+        sleep(2);
+        $afterPing = $this->getCheck($check['uuid']);
+        echo "  Status after ping: {$afterPing['status']}\n";
+
+        // Record the states we observe
+        $states = ['up' => date('H:i:s')];
+
+        // Now wait and poll - should go: up -> grace -> down
+        echo "  Waiting for state transitions (up to 3 minutes)...\n";
+
+        $startTime = time();
+        $maxWait = ($timeout + $grace + 30); // Extra 30s buffer
+        $lastStatus = 'up';
+
+        while ((time() - $startTime) < $maxWait) {
+            sleep(15); // Check every 15 seconds
+
+            $current = $this->getCheck($check['uuid']);
+            $elapsed = time() - $startTime;
+
+            if ($current['status'] !== $lastStatus) {
+                $states[$current['status']] = date('H:i:s') . " (+{$elapsed}s)";
+                echo "    -> Status changed to: {$current['status']} at +{$elapsed}s\n";
+                $lastStatus = $current['status'];
+
+                // If we've reached "down", we're done
+                if ($current['status'] === 'down') {
+                    break;
+                }
+            }
+        }
+
+        echo "  Final state transitions observed:\n";
+        foreach ($states as $state => $time) {
+            echo "    $state: $time\n";
+        }
+
+        // Verify we saw the expected transitions
+        $this->assertArrayHasKey('grace', $states, 'Should have transitioned to grace state');
+        $this->assertArrayHasKey('down', $states, 'Should have transitioned to down state');
+    }
+
+    /**
+     * Test 4: Verify a NEVER-PINGED check does NOT alert.
+     * Create check, wait past timeout+grace, confirm still "new" (not "down").
+     */
+    public function testNeverPingedCheckDoesNotAlert(): void
+    {
+        $timeout = 60;
+        $grace = 60;
+
+        $check = $this->createCheck([
+            'name' => 'poc-test-never-pinged-' . time(),
+            'timeout' => $timeout,
+            'grace' => $grace,
+        ]);
+
+        $this->assertNotNull($check);
+        $this->createdChecks[] = $check['uuid'];
+
+        echo "\n  Created check (NOT pinging): {$check['uuid']}\n";
+        echo "  Initial status: {$check['status']}\n";
+        echo "  Waiting 2.5 minutes (past timeout+grace)...\n";
+
+        // Wait past the timeout + grace period
+        sleep(150); // 2.5 minutes
+
+        $final = $this->getCheck($check['uuid']);
+        echo "  Final status: {$final['status']}\n";
+
+        // Per our source code analysis, this should STILL be "new"
+        $this->assertEquals('new', $final['status'],
+            'Never-pinged check should remain "new", not transition to "down"');
+    }
+
+    // =========================================================================
+    // API Helper Methods
+    // =========================================================================
+
+    private function createCheck(array $params): ?array
+    {
+        $ch = curl_init($this->baseUrl . '/checks/');
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => json_encode($params),
+            CURLOPT_HTTPHEADER => [
+                'X-Api-Key: ' . $this->apiKey,
+                'Content-Type: application/json',
+            ],
+        ]);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($httpCode !== 201) {
+            echo "  ERROR creating check: HTTP $httpCode - $response\n";
+            return null;
+        }
+
+        return json_decode($response, true);
+    }
+
+    private function getCheck(string $uuid): ?array
+    {
+        $ch = curl_init($this->baseUrl . '/checks/' . $uuid);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER => [
+                'X-Api-Key: ' . $this->apiKey,
+            ],
+        ]);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($httpCode !== 200) {
+            echo "  ERROR getting check: HTTP $httpCode\n";
+            return null;
+        }
+
+        return json_decode($response, true);
+    }
+
+    private function deleteCheck(string $uuid): bool
+    {
+        $ch = curl_init($this->baseUrl . '/checks/' . $uuid);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_CUSTOMREQUEST => 'DELETE',
+            CURLOPT_HTTPHEADER => [
+                'X-Api-Key: ' . $this->apiKey,
+            ],
+        ]);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        return $httpCode === 200;
+    }
+
+    private function ping(string $pingUrl): string
+    {
+        $ch = curl_init($pingUrl);
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+
+        $response = curl_exec($ch);
+        curl_close($ch);
+
+        return $response ?: 'no response';
+    }
+
+    private function getFlips(string $uuid): array
+    {
+        $ch = curl_init($this->baseUrl . '/checks/' . $uuid . '/flips/');
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HTTPHEADER => [
+                'X-Api-Key: ' . $this->apiKey,
+            ],
+        ]);
+
+        $response = curl_exec($ch);
+        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+
+        if ($httpCode !== 200) {
+            return [];
+        }
+
+        return json_decode($response, true)['flips'] ?? [];
+    }
+}

--- a/backend/tests/Unit/Services/HealthchecksClientTest.php
+++ b/backend/tests/Unit/Services/HealthchecksClientTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Tests\Unit\Services;
+
+use HotTub\Services\HealthchecksClient;
+use HotTub\Services\NullHealthchecksClient;
+use HotTub\Services\HealthchecksClientFactory;
+use HotTub\Contracts\HealthchecksClientInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for Healthchecks.io client classes.
+ *
+ * These tests verify the client behavior without making real API calls.
+ */
+class HealthchecksClientTest extends TestCase
+{
+    // =========================================================================
+    // NullHealthchecksClient Tests (feature disabled)
+    // =========================================================================
+
+    public function testNullClientIsDisabled(): void
+    {
+        $client = new NullHealthchecksClient();
+        $this->assertFalse($client->isEnabled());
+    }
+
+    public function testNullClientCreateCheckReturnsNull(): void
+    {
+        $client = new NullHealthchecksClient();
+        $result = $client->createCheck('test-job', 120, 60);
+        $this->assertNull($result);
+    }
+
+    public function testNullClientPingReturnsTrue(): void
+    {
+        $client = new NullHealthchecksClient();
+        $result = $client->ping('https://hc-ping.com/fake-uuid');
+        $this->assertTrue($result);
+    }
+
+    public function testNullClientDeleteReturnsTrue(): void
+    {
+        $client = new NullHealthchecksClient();
+        $result = $client->delete('fake-uuid');
+        $this->assertTrue($result);
+    }
+
+    public function testNullClientGetCheckReturnsNull(): void
+    {
+        $client = new NullHealthchecksClient();
+        $result = $client->getCheck('fake-uuid');
+        $this->assertNull($result);
+    }
+
+    // =========================================================================
+    // Factory Tests
+    // =========================================================================
+
+    public function testFactoryReturnsNullClientWhenNoApiKey(): void
+    {
+        $factory = new HealthchecksClientFactory([
+            'HEALTHCHECKS_IO_KEY' => null,
+        ]);
+
+        $client = $factory->create();
+
+        $this->assertInstanceOf(NullHealthchecksClient::class, $client);
+        $this->assertFalse($client->isEnabled());
+    }
+
+    public function testFactoryReturnsNullClientWhenEmptyApiKey(): void
+    {
+        $factory = new HealthchecksClientFactory([
+            'HEALTHCHECKS_IO_KEY' => '',
+        ]);
+
+        $client = $factory->create();
+
+        $this->assertInstanceOf(NullHealthchecksClient::class, $client);
+    }
+
+    public function testFactoryReturnsRealClientWhenApiKeyPresent(): void
+    {
+        $factory = new HealthchecksClientFactory([
+            'HEALTHCHECKS_IO_KEY' => 'test-api-key',
+        ]);
+
+        $client = $factory->create();
+
+        $this->assertInstanceOf(HealthchecksClient::class, $client);
+        $this->assertTrue($client->isEnabled());
+    }
+
+    public function testFactoryCanOverrideChannelId(): void
+    {
+        $factory = new HealthchecksClientFactory([
+            'HEALTHCHECKS_IO_KEY' => 'test-api-key',
+            'HEALTHCHECKS_IO_CHANNEL' => 'custom-channel-uuid',
+        ]);
+
+        $client = $factory->create();
+
+        // The channel should be stored in the client
+        $this->assertInstanceOf(HealthchecksClient::class, $client);
+    }
+
+    // =========================================================================
+    // HealthchecksClient Unit Tests (with mocked HTTP)
+    // =========================================================================
+
+    public function testClientIsEnabled(): void
+    {
+        $client = new HealthchecksClient('test-api-key');
+        $this->assertTrue($client->isEnabled());
+    }
+
+    public function testClientImplementsInterface(): void
+    {
+        $client = new HealthchecksClient('test-api-key');
+        $this->assertInstanceOf(HealthchecksClientInterface::class, $client);
+    }
+}


### PR DESCRIPTION
## Summary
- Integrates Healthchecks.io API to monitor scheduled cron jobs
- Alerts via email if a scheduled job fails to execute
- Feature flag design: silently disabled if API key not configured

## Changes
- New `HealthchecksClient` service with factory pattern
- `SchedulerService` creates health checks when scheduling jobs
- `cron-runner.sh` deletes health check on successful execution
- Deploy workflow updated to include new secrets

## Test plan
- [x] Unit tests for client classes (11 tests)
- [x] Live API integration tests (7 tests)  
- [x] SchedulerService integration tests (8 tests)
- [x] Full test suite passes (319 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)