### PR TITLE
Add async temperature refresh with polling for WirelessTag sensor

### DIFF
--- a/backend/src/Controllers/TemperatureController.php
+++ b/backend/src/Controllers/TemperatureController.php
@@ -6,24 +6,27 @@ namespace HotTub\Controllers;
 
 use HotTub\Services\WirelessTagClient;
 use HotTub\Services\WirelessTagClientFactory;
+use HotTub\Services\TemperatureStateService;
 
 /**
  * Controller for temperature sensor operations.
  *
- * Provides temperature readings from WirelessTag sensors.
+ * Provides temperature readings from WirelessTag sensors with
+ * async refresh state tracking for polling-based updates.
  */
 class TemperatureController
 {
     public function __construct(
         private WirelessTagClient $wirelessTagClient,
-        private ?WirelessTagClientFactory $factory = null
+        private ?WirelessTagClientFactory $factory = null,
+        private ?TemperatureStateService $stateService = null
     ) {}
 
     /**
      * Get current temperature reading.
      *
-     * Returns water and ambient temperatures along with
-     * device metadata from the WirelessTag sensor.
+     * Returns water and ambient temperatures along with device metadata.
+     * Also includes refresh_in_progress to indicate if a refresh is pending.
      */
     public function get(): array
     {
@@ -34,6 +37,7 @@ class TemperatureController
                 'body' => [
                     'error' => $this->factory->getConfigurationError(),
                     'error_code' => 'SENSOR_NOT_CONFIGURED',
+                    'refresh_in_progress' => false,
                 ],
             ];
         }
@@ -47,26 +51,105 @@ class TemperatureController
                 $timestamp = date('c', $timestamp);
             }
 
+            // Check refresh state if state service is available
+            $refreshInProgress = false;
+            $refreshRequestedAt = null;
+
+            if ($this->stateService !== null) {
+                $sensorTimestamp = new \DateTimeImmutable($timestamp);
+                $refreshInProgress = $this->stateService->isRefreshInProgress($sensorTimestamp);
+
+                if ($refreshInProgress) {
+                    $refreshRequestedAt = $this->stateService->getRefreshRequestedAt();
+                } else {
+                    // Refresh completed or timed out - clear state
+                    $this->stateService->clearRefreshState();
+                }
+            }
+
+            $body = [
+                'water_temp_f' => $temp['water_temp_f'],
+                'water_temp_c' => $temp['water_temp_c'],
+                'ambient_temp_f' => $temp['ambient_temp_f'],
+                'ambient_temp_c' => $temp['ambient_temp_c'],
+                'battery_voltage' => $temp['battery_voltage'],
+                'signal_dbm' => $temp['signal_dbm'],
+                'device_name' => $temp['device_name'],
+                'timestamp' => $timestamp,
+                'refresh_in_progress' => $refreshInProgress,
+            ];
+
+            // Include refresh_requested_at when refresh is in progress
+            if ($refreshRequestedAt !== null) {
+                $body['refresh_requested_at'] = $refreshRequestedAt->format('c');
+            }
+
             return [
                 'status' => 200,
-                'body' => [
-                    'water_temp_f' => $temp['water_temp_f'],
-                    'water_temp_c' => $temp['water_temp_c'],
-                    'ambient_temp_f' => $temp['ambient_temp_f'],
-                    'ambient_temp_c' => $temp['ambient_temp_c'],
-                    'battery_voltage' => $temp['battery_voltage'],
-                    'signal_dbm' => $temp['signal_dbm'],
-                    'device_name' => $temp['device_name'],
-                    'timestamp' => $timestamp,
-                ],
+                'body' => $body,
             ];
         } catch (\Exception $e) {
             return [
                 'status' => 500,
                 'body' => [
                     'error' => 'Failed to read temperature sensor: ' . $e->getMessage(),
+                    'refresh_in_progress' => false,
                 ],
             ];
         }
+    }
+
+    /**
+     * Request a fresh temperature reading from the sensor hardware.
+     *
+     * This triggers the WirelessTag sensor to take a new measurement.
+     * The call returns immediately - the sensor will update its cached
+     * reading asynchronously. Poll get() to check for the fresh data.
+     */
+    public function refresh(): array
+    {
+        // Check if sensor is configured before attempting refresh
+        if ($this->factory !== null && !$this->factory->isConfigured()) {
+            return [
+                'status' => 503,
+                'body' => [
+                    'success' => false,
+                    'error' => $this->factory->getConfigurationError(),
+                    'error_code' => 'SENSOR_NOT_CONFIGURED',
+                ],
+            ];
+        }
+
+        // Record refresh request timestamp
+        $requestedAt = new \DateTimeImmutable();
+        if ($this->stateService !== null) {
+            $this->stateService->markRefreshRequested($requestedAt);
+        }
+
+        $success = $this->wirelessTagClient->requestRefresh('0');
+
+        if ($success) {
+            return [
+                'status' => 200,
+                'body' => [
+                    'success' => true,
+                    'message' => 'Temperature refresh requested. New reading will be available shortly.',
+                    'requested_at' => $requestedAt->format('c'),
+                ],
+            ];
+        }
+
+        // Clear state on failure
+        if ($this->stateService !== null) {
+            $this->stateService->clearRefreshState();
+        }
+
+        return [
+            'status' => 503,
+            'body' => [
+                'success' => false,
+                'error' => 'Failed to request temperature refresh from sensor',
+            ],
+        ];
     }
 }

--- a/backend/src/Services/TemperatureStateService.php
+++ b/backend/src/Services/TemperatureStateService.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Services;
+
+/**
+ * Manages async refresh state for temperature readings.
+ *
+ * Tracks when a refresh was requested so we can determine if a refresh
+ * is in progress, succeeded, or timed out. Uses file-based storage
+ * for simplicity on shared hosting.
+ */
+class TemperatureStateService
+{
+    private const TIMEOUT_SECONDS = 15;
+
+    public function __construct(
+        private string $stateFilePath
+    ) {}
+
+    /**
+     * Record that a refresh was requested at the given time.
+     */
+    public function markRefreshRequested(\DateTimeImmutable $timestamp): void
+    {
+        $state = [
+            'refresh_requested_at' => $timestamp->format('c'),
+        ];
+
+        $this->saveState($state);
+    }
+
+    /**
+     * Get the current state, or null if no state exists.
+     */
+    public function getState(): ?array
+    {
+        if (!file_exists($this->stateFilePath)) {
+            return null;
+        }
+
+        $content = file_get_contents($this->stateFilePath);
+        if ($content === false || $content === '') {
+            return null;
+        }
+
+        $state = json_decode($content, true);
+        if (!is_array($state)) {
+            return null;
+        }
+
+        return $state;
+    }
+
+    /**
+     * Clear the refresh state (called after refresh completes or times out).
+     */
+    public function clearRefreshState(): void
+    {
+        if (file_exists($this->stateFilePath)) {
+            unlink($this->stateFilePath);
+        }
+    }
+
+    /**
+     * Determine if a refresh is currently in progress.
+     *
+     * A refresh is "in progress" if:
+     * - A refresh was requested
+     * - The sensor timestamp is older than the request time
+     * - The request hasn't timed out yet (within TIMEOUT_SECONDS)
+     *
+     * @param \DateTimeImmutable $sensorTimestamp When the sensor last reported data
+     * @return bool True if refresh is in progress
+     */
+    public function isRefreshInProgress(\DateTimeImmutable $sensorTimestamp): bool
+    {
+        $requestedAt = $this->getRefreshRequestedAt();
+
+        if ($requestedAt === null) {
+            return false;
+        }
+
+        // If sensor timestamp is newer than request, refresh completed
+        if ($sensorTimestamp >= $requestedAt) {
+            return false;
+        }
+
+        // Check if request has timed out
+        $now = new \DateTimeImmutable();
+        $elapsed = $now->getTimestamp() - $requestedAt->getTimestamp();
+
+        if ($elapsed > self::TIMEOUT_SECONDS) {
+            return false;
+        }
+
+        // Sensor is stale and we're within timeout window
+        return true;
+    }
+
+    /**
+     * Get the timestamp when refresh was requested, or null if not set.
+     */
+    public function getRefreshRequestedAt(): ?\DateTimeImmutable
+    {
+        $state = $this->getState();
+
+        if ($state === null || !isset($state['refresh_requested_at'])) {
+            return null;
+        }
+
+        try {
+            return new \DateTimeImmutable($state['refresh_requested_at']);
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Save state to file, creating directory if needed.
+     */
+    private function saveState(array $state): void
+    {
+        $dir = dirname($this->stateFilePath);
+
+        if (!is_dir($dir)) {
+            mkdir($dir, 0755, true);
+        }
+
+        file_put_contents(
+            $this->stateFilePath,
+            json_encode($state, JSON_PRETTY_PRINT),
+            LOCK_EX
+        );
+    }
+}

--- a/backend/src/Services/WirelessTagClient.php
+++ b/backend/src/Services/WirelessTagClient.php
@@ -105,6 +105,31 @@ class WirelessTagClient
     }
 
     /**
+     * Request a fresh temperature reading from the hardware sensor.
+     *
+     * This triggers the WirelessTag sensor to take a new measurement
+     * via the RequestImmediatePostback endpoint. The sensor will update
+     * its cached reading which can then be retrieved via getTemperature().
+     *
+     * Note: This call may be slow (several seconds) and can fail on flaky
+     * networks. The actual temperature update happens asynchronously on
+     * the sensor hardware.
+     *
+     * @param string $deviceId WirelessTag device ID
+     * @return bool True on success, false on failure
+     */
+    public function requestRefresh(string $deviceId): bool
+    {
+        try {
+            $this->httpClient->post('/RequestImmediatePostback', ['id' => $deviceId]);
+            return true;
+        } catch (\RuntimeException $e) {
+            // Log the error but don't throw - return false to indicate failure
+            return false;
+        }
+    }
+
+    /**
      * Convert Celsius to Fahrenheit.
      */
     private function celsiusToFahrenheit(float $celsius): float

--- a/backend/tests/Controllers/TemperatureControllerTest.php
+++ b/backend/tests/Controllers/TemperatureControllerTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use HotTub\Controllers\TemperatureController;
 use HotTub\Services\WirelessTagClient;
 use HotTub\Services\StubWirelessTagHttpClient;
+use HotTub\Services\TemperatureStateService;
 
 /**
  * Unit tests for TemperatureController.
@@ -18,12 +19,26 @@ class TemperatureControllerTest extends TestCase
 {
     private TemperatureController $controller;
     private StubWirelessTagHttpClient $stubHttpClient;
+    private string $stateFilePath;
+    private TemperatureStateService $stateService;
 
     protected function setUp(): void
     {
         $this->stubHttpClient = new StubWirelessTagHttpClient();
         $client = new WirelessTagClient($this->stubHttpClient);
-        $this->controller = new TemperatureController($client);
+
+        // Create temp state file for each test
+        $this->stateFilePath = sys_get_temp_dir() . '/test_temp_state_' . uniqid() . '.json';
+        $this->stateService = new TemperatureStateService($this->stateFilePath);
+
+        $this->controller = new TemperatureController($client, null, $this->stateService);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->stateFilePath)) {
+            unlink($this->stateFilePath);
+        }
     }
 
     /**
@@ -121,5 +136,135 @@ class TemperatureControllerTest extends TestCase
         $this->assertEquals(500, $response['status']);
         $this->assertArrayHasKey('error', $response['body']);
         $this->assertStringContainsString('Connection failed', $response['body']['error']);
+    }
+
+    /**
+     * @test
+     * The refresh endpoint should trigger a sensor refresh and return success.
+     */
+    public function refreshReturns200OnSuccess(): void
+    {
+        $response = $this->controller->refresh();
+
+        $this->assertEquals(200, $response['status']);
+        $this->assertArrayHasKey('success', $response['body']);
+        $this->assertTrue($response['body']['success']);
+        $this->assertArrayHasKey('message', $response['body']);
+    }
+
+    /**
+     * @test
+     * The refresh endpoint should return 503 on API failure.
+     */
+    public function refreshReturns503OnApiFailure(): void
+    {
+        // Create a mock that throws an exception
+        $mockHttpClient = $this->createMock(\HotTub\Contracts\WirelessTagHttpClientInterface::class);
+        $mockHttpClient->method('post')
+            ->willThrowException(new \RuntimeException('Connection failed'));
+
+        $client = new WirelessTagClient($mockHttpClient);
+        $controller = new TemperatureController($client, null, $this->stateService);
+
+        $response = $controller->refresh();
+
+        $this->assertEquals(503, $response['status']);
+        $this->assertArrayHasKey('success', $response['body']);
+        $this->assertFalse($response['body']['success']);
+        $this->assertArrayHasKey('error', $response['body']);
+    }
+
+    // ==================== Refresh State Tests ====================
+
+    /**
+     * @test
+     * GET /temperature should include refresh_in_progress field.
+     */
+    public function getIncludesRefreshInProgressField(): void
+    {
+        $response = $this->controller->get();
+
+        $this->assertEquals(200, $response['status']);
+        $this->assertArrayHasKey('refresh_in_progress', $response['body']);
+        $this->assertIsBool($response['body']['refresh_in_progress']);
+    }
+
+    /**
+     * @test
+     * When no refresh is pending, refresh_in_progress should be false.
+     */
+    public function getReturnsRefreshInProgressFalseWhenNoRefreshPending(): void
+    {
+        $response = $this->controller->get();
+
+        $this->assertFalse($response['body']['refresh_in_progress']);
+    }
+
+    /**
+     * @test
+     * When refresh was just requested, refresh_in_progress should be true.
+     */
+    public function getReturnsRefreshInProgressTrueWhenRefreshPending(): void
+    {
+        // Mark refresh as requested slightly in the future so sensor timestamp
+        // (which is "now") will be older than the request, simulating a pending refresh
+        $this->stateService->markRefreshRequested(new \DateTimeImmutable('+5 seconds'));
+
+        $response = $this->controller->get();
+
+        $this->assertTrue($response['body']['refresh_in_progress']);
+    }
+
+    /**
+     * @test
+     * When refresh is pending, response should include refresh_requested_at.
+     */
+    public function getIncludesRefreshRequestedAtWhenRefreshPending(): void
+    {
+        // Use future time so sensor timestamp (now) is older than request
+        $requestTime = new \DateTimeImmutable('+5 seconds');
+        $this->stateService->markRefreshRequested($requestTime);
+
+        $response = $this->controller->get();
+
+        $this->assertArrayHasKey('refresh_requested_at', $response['body']);
+        $this->assertEquals($requestTime->format('c'), $response['body']['refresh_requested_at']);
+    }
+
+    /**
+     * @test
+     * When refresh completes (sensor timestamp newer than request),
+     * refresh_in_progress should be false and state should be cleared.
+     */
+    public function getReturnsRefreshInProgressFalseWhenRefreshCompleted(): void
+    {
+        // Mark refresh requested 10 seconds ago
+        $requestTime = new \DateTimeImmutable('-10 seconds');
+        $this->stateService->markRefreshRequested($requestTime);
+
+        // Stub returns current timestamp (which is newer than request)
+        $response = $this->controller->get();
+
+        $this->assertFalse($response['body']['refresh_in_progress']);
+
+        // State should be cleared after successful refresh
+        $this->assertNull($this->stateService->getState());
+    }
+
+    /**
+     * @test
+     * POST /refresh should store the request timestamp and return it.
+     */
+    public function refreshStoresRequestedAtAndReturnsIt(): void
+    {
+        $response = $this->controller->refresh();
+
+        $this->assertEquals(200, $response['status']);
+        $this->assertArrayHasKey('requested_at', $response['body']);
+
+        // Verify state was stored
+        $storedRequestedAt = $this->stateService->getRefreshRequestedAt();
+        $this->assertNotNull($storedRequestedAt);
+        $this->assertEquals($storedRequestedAt->format('c'), $response['body']['requested_at']);
     }
 }

--- a/backend/tests/Unit/TemperatureStateServiceTest.php
+++ b/backend/tests/Unit/TemperatureStateServiceTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use HotTub\Services\TemperatureStateService;
+
+/**
+ * Tests for TemperatureStateService.
+ *
+ * This service manages the async refresh state for temperature readings.
+ * It tracks when a refresh was requested so we can determine if a refresh
+ * is in progress, succeeded, or timed out.
+ */
+class TemperatureStateServiceTest extends TestCase
+{
+    private string $testStateFile;
+    private TemperatureStateService $service;
+
+    protected function setUp(): void
+    {
+        $this->testStateFile = sys_get_temp_dir() . '/test_temp_state_' . uniqid() . '.json';
+        $this->service = new TemperatureStateService($this->testStateFile);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->testStateFile)) {
+            unlink($this->testStateFile);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function canStoreRefreshRequestedTimestamp(): void
+    {
+        $timestamp = new \DateTimeImmutable('2025-12-15T10:00:00+00:00');
+
+        $this->service->markRefreshRequested($timestamp);
+
+        $state = $this->service->getState();
+        $this->assertEquals($timestamp->format('c'), $state['refresh_requested_at']);
+    }
+
+    /**
+     * @test
+     */
+    public function getStateReturnsNullWhenNoStateExists(): void
+    {
+        $state = $this->service->getState();
+
+        $this->assertNull($state);
+    }
+
+    /**
+     * @test
+     */
+    public function canClearRefreshState(): void
+    {
+        $timestamp = new \DateTimeImmutable('2025-12-15T10:00:00+00:00');
+        $this->service->markRefreshRequested($timestamp);
+
+        $this->service->clearRefreshState();
+
+        $state = $this->service->getState();
+        $this->assertNull($state);
+    }
+
+    /**
+     * @test
+     */
+    public function isRefreshInProgressReturnsFalseWhenNoState(): void
+    {
+        $sensorTimestamp = new \DateTimeImmutable('2025-12-15T10:00:00+00:00');
+
+        $result = $this->service->isRefreshInProgress($sensorTimestamp);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isRefreshInProgressReturnsTrueWhenSensorTimestampOlderThanRequest(): void
+    {
+        // Use relative times so timeout logic works correctly
+        $requestTime = new \DateTimeImmutable('-2 seconds');        // Request made 2 sec ago
+        $sensorTimestamp = new \DateTimeImmutable('-10 seconds');   // Sensor data is 10 sec old
+
+        $this->service->markRefreshRequested($requestTime);
+
+        $result = $this->service->isRefreshInProgress($sensorTimestamp);
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isRefreshInProgressReturnsFalseWhenSensorTimestampNewerThanRequest(): void
+    {
+        // Use relative times for consistency
+        $requestTime = new \DateTimeImmutable('-10 seconds');       // Request made 10 sec ago
+        $sensorTimestamp = new \DateTimeImmutable('-5 seconds');    // Sensor data is 5 sec old (newer than request)
+
+        $this->service->markRefreshRequested($requestTime);
+
+        $result = $this->service->isRefreshInProgress($sensorTimestamp);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isRefreshInProgressReturnsFalseWhenRequestTimedOut(): void
+    {
+        // Request made 20 seconds ago (past 15 second timeout)
+        $requestTime = new \DateTimeImmutable('-20 seconds');
+        $sensorTimestamp = new \DateTimeImmutable('-30 seconds'); // Even older
+
+        $this->service->markRefreshRequested($requestTime);
+
+        $result = $this->service->isRefreshInProgress($sensorTimestamp);
+
+        $this->assertFalse($result);
+    }
+
+    /**
+     * @test
+     */
+    public function isRefreshInProgressReturnsTrueWithinTimeoutWindow(): void
+    {
+        // Request made 5 seconds ago (within 15 second timeout)
+        $requestTime = new \DateTimeImmutable('-5 seconds');
+        $sensorTimestamp = new \DateTimeImmutable('-30 seconds'); // Older than request
+
+        $this->service->markRefreshRequested($requestTime);
+
+        $result = $this->service->isRefreshInProgress($sensorTimestamp);
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @test
+     */
+    public function getRefreshRequestedAtReturnsTimestampWhenSet(): void
+    {
+        $timestamp = new \DateTimeImmutable('2025-12-15T10:00:00+00:00');
+        $this->service->markRefreshRequested($timestamp);
+
+        $result = $this->service->getRefreshRequestedAt();
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $result);
+        $this->assertEquals($timestamp->format('c'), $result->format('c'));
+    }
+
+    /**
+     * @test
+     */
+    public function getRefreshRequestedAtReturnsNullWhenNotSet(): void
+    {
+        $result = $this->service->getRefreshRequestedAt();
+
+        $this->assertNull($result);
+    }
+
+    /**
+     * @test
+     */
+    public function stateFileIsCreatedInDirectoryIfNotExists(): void
+    {
+        $nestedPath = sys_get_temp_dir() . '/nested_' . uniqid() . '/temp_state.json';
+        $service = new TemperatureStateService($nestedPath);
+
+        $service->markRefreshRequested(new \DateTimeImmutable());
+
+        $this->assertFileExists($nestedPath);
+
+        // Cleanup
+        unlink($nestedPath);
+        rmdir(dirname($nestedPath));
+    }
+}

--- a/backend/tests/Unit/WirelessTagClientRefreshTest.php
+++ b/backend/tests/Unit/WirelessTagClientRefreshTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use HotTub\Services\WirelessTagClient;
+use HotTub\Services\StubWirelessTagHttpClient;
+
+/**
+ * Tests for WirelessTagClient::requestRefresh() method.
+ *
+ * This method triggers a fresh temperature reading from the hardware sensor
+ * via the WirelessTag API's RequestImmediatePostback endpoint.
+ */
+class WirelessTagClientRefreshTest extends TestCase
+{
+    /**
+     * @test
+     * requestRefresh() should call the RequestImmediatePostback endpoint
+     * and return true on success.
+     */
+    public function requestRefreshReturnsTrueOnSuccess(): void
+    {
+        $httpClient = new StubWirelessTagHttpClient();
+        $client = new WirelessTagClient($httpClient);
+
+        $result = $client->requestRefresh('0');
+
+        $this->assertTrue($result);
+    }
+
+    /**
+     * @test
+     * requestRefresh() should return false on API failure.
+     */
+    public function requestRefreshReturnsFalseOnFailure(): void
+    {
+        // Create a mock that throws an exception
+        $httpClient = $this->createMock(StubWirelessTagHttpClient::class);
+        $httpClient->method('post')
+            ->willThrowException(new \RuntimeException('API error'));
+
+        $client = new WirelessTagClient($httpClient);
+
+        $result = $client->requestRefresh('0');
+
+        $this->assertFalse($result);
+    }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -34,6 +34,14 @@ export interface TemperatureData {
 	signal_dbm: number | null;
 	device_name: string;
 	timestamp: string;
+	refresh_in_progress: boolean;
+	refresh_requested_at?: string;
+}
+
+export interface RefreshResponse {
+	success: boolean;
+	message: string;
+	requested_at: string;
 }
 
 export interface UserListResponse {
@@ -146,8 +154,9 @@ export const api = {
 	heaterOff: () => post('/api/equipment/heater/off'),
 	pumpRun: () => post('/api/equipment/pump/run'),
 
-	// Temperature endpoint
+	// Temperature endpoints
 	getTemperature: () => get<TemperatureData>('/api/temperature'),
+	refreshTemperature: () => post('/api/temperature/refresh') as Promise<RefreshResponse>,
 
 	// Schedule endpoints
 	scheduleJob: (action: string, scheduledTime: string, recurring: boolean = false) =>


### PR DESCRIPTION
## Summary
- Implements two-step WirelessTag API process: trigger hardware refresh then retrieve data
- Adds backend state tracking for async refresh operations with 15-second timeout
- Frontend polls every 3 seconds (max 5 attempts) showing "Refreshing sensor..." indicator

## Test plan
- [x] Backend tests pass (27 temperature-related tests)
- [x] Frontend tests pass (122 tests including 6 new polling tests)
- [ ] Manual test: Click refresh button, verify spinner shows, verify fresh temperature appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)