### PR TITLE
Enable blinds feature in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,6 +69,8 @@ jobs:
           WIRELESSTAG_DEVICE_ID=${{ secrets.WIRELESSTAG_DEVICE_ID }}
           HEALTHCHECKS_IO_KEY=${{ secrets.HEALTHCHECKS_IO_KEY }}
           HEALTHCHECKS_IO_CHANNEL=${{ secrets.HEALTHCHECKS_IO_CHANNEL }}
+          # Optional Features
+          BLINDS_FEATURE_ENABLED=true
           EOF
 
       # Generate CRON_JWT for scheduled job authentication


### PR DESCRIPTION
## Summary
- Add BLINDS_FEATURE_ENABLED=true to the deploy workflow .env generation

This enables the blinds control feature on production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)