### PR TITLE
Fix ESP32 refresh incorrectly updating WirelessTag timestamp

### DIFF
--- a/frontend/e2e/temperature.spec.ts
+++ b/frontend/e2e/temperature.spec.ts
@@ -210,6 +210,31 @@ test.describe('Temperature Display Feature', () => {
 			// Temperature should still be visible in WirelessTag section after refresh
 			await expect(page.locator('[data-testid="wirelesstag-readings"]').getByText('Water:')).toBeVisible({ timeout: 15000 });
 		});
+
+		test('clicking ESP32 refresh does NOT update WirelessTag timestamp', async ({ page }) => {
+			// Wait for both sections to load
+			await expect(page.locator('[data-testid="esp32-readings"]')).toBeVisible({ timeout: 10000 });
+			await expect(page.locator('[data-testid="wirelesstag-readings"]')).toBeVisible({ timeout: 10000 });
+
+			// Get the initial WirelessTag timestamp
+			const wirelesstagTimestamp = page.locator('[data-testid="wirelesstag-timestamp"]');
+			await expect(wirelesstagTimestamp).toBeVisible();
+			const initialTimestamp = await wirelesstagTimestamp.textContent();
+
+			// Wait a moment to ensure any timestamp would be different
+			await page.waitForTimeout(1500);
+
+			// Click ESP32 refresh
+			const esp32Refresh = page.locator('[data-testid="esp32-refresh"]');
+			await esp32Refresh.click();
+
+			// Wait for refresh to complete
+			await expect(page.locator('[data-testid="esp32-readings"]').getByText('Water:')).toBeVisible({ timeout: 10000 });
+
+			// WirelessTag timestamp should NOT have changed
+			const afterTimestamp = await wirelesstagTimestamp.textContent();
+			expect(afterTimestamp).toBe(initialTimestamp);
+		});
 	});
 
 	test.describe('No Global Refresh Button', () => {

--- a/frontend/src/lib/components/TemperaturePanel.svelte
+++ b/frontend/src/lib/components/TemperaturePanel.svelte
@@ -86,10 +86,10 @@
 		refreshingEsp32 = true;
 
 		try {
-			// Just re-fetch all temperatures - ESP32 timestamp comes from backend
+			// Re-fetch all temperatures - ESP32 timestamp comes from backend
+			// Note: We do NOT update wirelesstagFetchedAt here since we're only refreshing ESP32
 			const data = await api.getAllTemperatures();
 			allTemps = data;
-			wirelesstagFetchedAt = Date.now();
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Failed to refresh';
 		} finally {


### PR DESCRIPTION
## Summary
- Fixed bug where clicking ESP32 refresh would also update WirelessTag "Last fetched" timestamp
- Root cause: copy-paste error left `wirelesstagFetchedAt = Date.now()` in ESP32 refresh handler
- Added regression test to prevent this bug from recurring

## Test plan
- [x] 19 temperature E2E tests passing
- [x] New test: "clicking ESP32 refresh does NOT update WirelessTag timestamp"

🤖 Generated with [Claude Code](https://claude.ai/code)