### PR TITLE
Fix POST body for ModSecurity compatibility

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,10 +145,12 @@ jobs:
           CRON_JWT=$(grep '^CRON_JWT=' backend/.env | cut -d'=' -f2-)
 
           echo "Calling cron health endpoint..."
+          # Note: -d '{}' is required - ModSecurity blocks POST requests without a body
           RESPONSE=$(curl -s -w "\n%{http_code}" -X POST \
             "${{ vars.API_BASE_URL }}/api/cron/health" \
             -H "Authorization: Bearer $CRON_JWT" \
             -H "Content-Type: application/json" \
+            -d '{}' \
             --max-time 30)
 
           HTTP_CODE=$(echo "$RESPONSE" | tail -n1)


### PR DESCRIPTION
## Summary
- Add empty JSON body (`-d '{}'`) to POST request in deploy workflow
- ModSecurity blocks POST requests without a body

## Root cause
Testing revealed that POST requests to the cron-health endpoint work when a body is included, but get 403 without one. The curl command was missing the `-d` flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)