### PR TITLE
Add ESP32 telnet debugger and fix sensor role persistence

### DIFF
--- a/backend/src/Routing/Router.php
+++ b/backend/src/Routing/Router.php
@@ -133,10 +133,10 @@ class Router
         // Extract parameter names from pattern
         preg_match_all('/\{([^}]+)\}/', $pattern, $paramNames);
 
-        // Build params array
+        // Build params array (URL-decode values since they come from the URL)
         $params = [];
         foreach ($paramNames[1] as $index => $name) {
-            $params[$name] = $matches[$index + 1];
+            $params[$name] = urldecode($matches[$index + 1]);
         }
 
         return $params;

--- a/esp32/lib/OneWireDiagnostics/onewire_diagnostics.cpp
+++ b/esp32/lib/OneWireDiagnostics/onewire_diagnostics.cpp
@@ -1,0 +1,47 @@
+#include "onewire_diagnostics.h"
+
+// DS18B20 error constants
+#define DEVICE_DISCONNECTED_C -127.0f
+#define POWER_ON_RESET_C 85.0f
+
+// OneWire family codes
+#define DS18S20_FAMILY 0x10
+#define DS18B20_FAMILY 0x28
+#define DS1822_FAMILY  0x22
+
+void OneWireDiagnostics::formatAddress(const uint8_t* address, char* buffer) {
+    snprintf(buffer, 24, "%02X:%02X:%02X:%02X:%02X:%02X:%02X:%02X",
+             address[0], address[1], address[2], address[3],
+             address[4], address[5], address[6], address[7]);
+}
+
+bool OneWireDiagnostics::isValidTemperature(float tempC) {
+    // Check for known error values
+    if (tempC == DEVICE_DISCONNECTED_C) return false;
+    if (tempC == POWER_ON_RESET_C) return false;
+    return true;
+}
+
+const char* OneWireDiagnostics::getTemperatureStatus(float tempC) {
+    if (tempC == DEVICE_DISCONNECTED_C) return "DISCONNECTED";
+    if (tempC == POWER_ON_RESET_C) return "POWER_ON_RESET";
+    return "OK";
+}
+
+const char* OneWireDiagnostics::getFamilyName(const uint8_t* address) {
+    switch (address[0]) {
+        case DS18B20_FAMILY: return "DS18B20";
+        case DS18S20_FAMILY: return "DS18S20";
+        case DS1822_FAMILY:  return "DS1822";
+        default: return "UNKNOWN";
+    }
+}
+
+const char* OneWireDiagnostics::busStateToString(BusState state) {
+    switch (state) {
+        case BUS_STATE_OK: return "OK";
+        case BUS_STATE_NO_DEVICES: return "NO_DEVICES";
+        case BUS_STATE_SHORT: return "SHORT_CIRCUIT";
+        default: return "UNKNOWN";
+    }
+}

--- a/esp32/lib/OneWireDiagnostics/onewire_diagnostics.h
+++ b/esp32/lib/OneWireDiagnostics/onewire_diagnostics.h
@@ -1,0 +1,40 @@
+#ifndef ONEWIRE_DIAGNOSTICS_H
+#define ONEWIRE_DIAGNOSTICS_H
+
+#include <cstdint>
+#include <cstdio>
+
+// Bus state enumeration
+enum BusState {
+    BUS_STATE_OK,
+    BUS_STATE_NO_DEVICES,
+    BUS_STATE_SHORT,
+    BUS_STATE_UNKNOWN
+};
+
+// Diagnostic result structure
+struct DiagnosticResult {
+    int deviceCount;
+    bool parasitic;
+    BusState busState;
+};
+
+class OneWireDiagnostics {
+public:
+    // Format DS18B20 address to string "XX:XX:XX:XX:XX:XX:XX:XX"
+    static void formatAddress(const uint8_t* address, char* buffer);
+
+    // Check if temperature reading is valid (not error code)
+    static bool isValidTemperature(float tempC);
+
+    // Get human-readable status for a temperature reading
+    static const char* getTemperatureStatus(float tempC);
+
+    // Get family name from device address
+    static const char* getFamilyName(const uint8_t* address);
+
+    // Convert bus state to string
+    static const char* busStateToString(BusState state);
+};
+
+#endif // ONEWIRE_DIAGNOSTICS_H

--- a/esp32/lib/TelnetDebugger/telnet_debugger.cpp
+++ b/esp32/lib/TelnetDebugger/telnet_debugger.cpp
@@ -1,0 +1,253 @@
+#include "telnet_debugger.h"
+#include <stdarg.h>
+
+// Static instance pointer for callbacks
+TelnetDebugger* TelnetDebugger::instance = nullptr;
+
+TelnetDebugger::TelnetDebugger(DallasTemperature* sensors, OneWire* oneWire, uint8_t oneWirePin)
+    : sensors(sensors), oneWire(oneWire), pin(oneWirePin), connected(false) {
+    instance = this;
+}
+
+// Static callbacks
+void TelnetDebugger::onTelnetConnect(String ip) {
+    if (instance) {
+        instance->connected = true;
+        Serial.printf("Telnet client connected from %s\n", ip.c_str());
+        instance->println("=================================");
+        instance->println("ESP32 Hot Tub Diagnostic Console");
+        instance->println("=================================");
+        instance->println("Type 'help' for commands");
+        instance->println("");
+    }
+}
+
+void TelnetDebugger::onTelnetDisconnect(String ip) {
+    if (instance) {
+        instance->connected = false;
+        Serial.printf("Telnet client disconnected from %s\n", ip.c_str());
+    }
+}
+
+void TelnetDebugger::onTelnetInput(String input) {
+    if (instance) {
+        instance->handleCommand(input);
+    }
+}
+
+bool TelnetDebugger::begin(uint16_t port) {
+    // Set up telnet callbacks using static functions
+    telnet.onConnect(onTelnetConnect);
+    telnet.onDisconnect(onTelnetDisconnect);
+    telnet.onInputReceived(onTelnetInput);
+
+    bool success = telnet.begin(port);
+    if (success) {
+        Serial.printf("Telnet server started on port %d\n", port);
+    } else {
+        Serial.println("Failed to start telnet server");
+    }
+    return success;
+}
+
+void TelnetDebugger::handleCommand(String input) {
+    input.trim();
+    if (input == "help") {
+        println("Commands:");
+        println("  diag    - Run full diagnostics");
+        println("  scan    - Scan OneWire bus");
+        println("  read    - Read all sensors");
+        println("  info    - Show connection info");
+        println("  help    - Show this help");
+    } else if (input == "diag") {
+        runDiagnostics();
+    } else if (input == "scan") {
+        scanOneWireBus();
+    } else if (input == "read") {
+        readAllSensors();
+    } else if (input == "info") {
+        printf("IP Address: %s\n", WiFi.localIP().toString().c_str());
+        printf("OneWire Pin: GPIO%d\n", pin);
+        printf("Uptime: %lu seconds\n", millis() / 1000);
+    } else if (input.length() > 0) {
+        printf("Unknown command: %s\n", input.c_str());
+        println("Type 'help' for available commands");
+    }
+}
+
+void TelnetDebugger::loop() {
+    telnet.loop();
+}
+
+void TelnetDebugger::print(const char* message) {
+    Serial.print(message);
+    if (connected) {
+        telnet.print(message);
+    }
+}
+
+void TelnetDebugger::println(const char* message) {
+    Serial.println(message);
+    if (connected) {
+        telnet.println(message);
+    }
+}
+
+void TelnetDebugger::printf(const char* format, ...) {
+    char buffer[256];
+    va_list args;
+    va_start(args, format);
+    vsnprintf(buffer, sizeof(buffer), format, args);
+    va_end(args);
+    print(buffer);
+}
+
+bool TelnetDebugger::isConnected() {
+    return connected;
+}
+
+String TelnetDebugger::getIP() {
+    return WiFi.localIP().toString();
+}
+
+void TelnetDebugger::runDiagnostics() {
+    println("");
+    println("========== FULL DIAGNOSTICS ==========");
+    println("");
+
+    // Connection info
+    println("--- Connection Info ---");
+    printf("WiFi SSID: %s\n", WiFi.SSID().c_str());
+    printf("IP Address: %s\n", WiFi.localIP().toString().c_str());
+    printf("Signal Strength: %d dBm\n", WiFi.RSSI());
+    printf("Uptime: %lu seconds\n", millis() / 1000);
+    println("");
+
+    // Hardware config
+    println("--- Hardware Config ---");
+    printf("OneWire Pin: GPIO%d\n", pin);
+    println("");
+
+    // Bus scan
+    scanOneWireBus();
+    println("");
+
+    // Sensor readings
+    readAllSensors();
+
+    println("");
+    println("========== END DIAGNOSTICS ==========");
+    println("");
+}
+
+void TelnetDebugger::scanOneWireBus() {
+    println("--- OneWire Bus Scan ---");
+
+    // Reset the bus and check for presence
+    uint8_t busState = oneWire->reset();
+    if (busState == 0) {
+        println("Bus State: NO PRESENCE PULSE DETECTED");
+        println("  -> No devices responding or bus shorted to ground");
+        return;
+    }
+    println("Bus State: Presence pulse detected (OK)");
+
+    // Check for parasitic power
+    sensors->begin();
+    bool parasitic = !sensors->isParasitePowerMode();
+    printf("Power Mode: %s\n", parasitic ? "PARASITIC (2-wire)" : "EXTERNAL (3-wire)");
+
+    // Count devices
+    int deviceCount = sensors->getDeviceCount();
+    printf("Devices Found: %d\n", deviceCount);
+
+    if (deviceCount == 0) {
+        println("");
+        println("WARNING: No devices found!");
+        println("Possible causes:");
+        println("  1. Incorrect wiring (check VCC, GND, DATA)");
+        println("  2. Missing or wrong pull-up resistor (need 4.7k)");
+        println("  3. Cable too long (try shorter cable)");
+        println("  4. Damaged sensor");
+        return;
+    }
+
+    println("");
+    println("--- Device Details ---");
+
+    // Enumerate all devices
+    DeviceAddress address;
+    for (int i = 0; i < deviceCount; i++) {
+        if (sensors->getAddress(address, i)) {
+            printDeviceInfo(address, i);
+        } else {
+            printf("Device %d: Failed to get address\n", i);
+        }
+    }
+}
+
+void TelnetDebugger::printDeviceInfo(uint8_t* address, int index) {
+    char addrStr[24];
+    OneWireDiagnostics::formatAddress(address, addrStr);
+
+    const char* familyName = OneWireDiagnostics::getFamilyName(address);
+
+    printf("\nDevice %d:\n", index);
+    printf("  Address: %s\n", addrStr);
+    printf("  Family: %s (0x%02X)\n", familyName, address[0]);
+
+    // Read resolution
+    uint8_t resolution = sensors->getResolution(address);
+    printf("  Resolution: %d bits\n", resolution);
+
+    // Validate CRC
+    if (OneWire::crc8(address, 7) != address[7]) {
+        println("  CRC: INVALID - address may be corrupted!");
+    } else {
+        println("  CRC: Valid");
+    }
+}
+
+void TelnetDebugger::readAllSensors() {
+    println("--- Sensor Readings ---");
+
+    int deviceCount = sensors->getDeviceCount();
+    if (deviceCount == 0) {
+        println("No sensors to read");
+        return;
+    }
+
+    println("Requesting temperatures...");
+    unsigned long startTime = millis();
+    sensors->requestTemperatures();
+    unsigned long elapsed = millis() - startTime;
+    printf("Conversion time: %lu ms\n", elapsed);
+    println("");
+
+    DeviceAddress address;
+    for (int i = 0; i < deviceCount; i++) {
+        if (sensors->getAddress(address, i)) {
+            char addrStr[24];
+            OneWireDiagnostics::formatAddress(address, addrStr);
+
+            float tempC = sensors->getTempC(address);
+            float tempF = tempC * 9.0 / 5.0 + 32.0;
+
+            const char* status = OneWireDiagnostics::getTemperatureStatus(tempC);
+
+            printf("Sensor %d (%s):\n", i, addrStr);
+            printf("  Temperature: %.2f C / %.2f F\n", tempC, tempF);
+            printf("  Status: %s\n", status);
+
+            if (!OneWireDiagnostics::isValidTemperature(tempC)) {
+                println("  WARNING: Invalid reading!");
+                if (tempC == -127.0) {
+                    println("  -> Device not responding (check wiring)");
+                } else if (tempC == 85.0) {
+                    println("  -> Power-on reset value (conversion may have failed)");
+                }
+            }
+            println("");
+        }
+    }
+}

--- a/esp32/lib/TelnetDebugger/telnet_debugger.h
+++ b/esp32/lib/TelnetDebugger/telnet_debugger.h
@@ -1,0 +1,62 @@
+#ifndef TELNET_DEBUGGER_H
+#define TELNET_DEBUGGER_H
+
+#include <Arduino.h>
+#include <ESPTelnet.h>
+#include <OneWire.h>
+#include <DallasTemperature.h>
+#include "onewire_diagnostics.h"
+
+// Default telnet port
+#define TELNET_PORT 23
+
+class TelnetDebugger {
+public:
+    TelnetDebugger(DallasTemperature* sensors, OneWire* oneWire, uint8_t oneWirePin);
+
+    // Initialize telnet server
+    bool begin(uint16_t port = TELNET_PORT);
+
+    // Must be called in loop() to handle telnet connections
+    void loop();
+
+    // Print to both Serial and Telnet (if connected)
+    void print(const char* message);
+    void println(const char* message);
+    void printf(const char* format, ...);
+
+    // Run full diagnostic scan and output results
+    void runDiagnostics();
+
+    // Check if a client is connected
+    bool isConnected();
+
+    // Get the IP address for connection
+    String getIP();
+
+    // Handle incoming command
+    void handleCommand(String input);
+
+    // Static instance for callbacks
+    static TelnetDebugger* instance;
+
+private:
+    ESPTelnet telnet;
+    DallasTemperature* sensors;
+    OneWire* oneWire;
+    uint8_t pin;
+    bool connected;
+
+    // Diagnostic helpers
+    void scanOneWireBus();
+    void readAllSensors();
+    void printBusState();
+    void printDeviceInfo(uint8_t* address, int index);
+
+    // Static callbacks for ESPTelnet
+    static void onTelnetConnect(String ip);
+    static void onTelnetDisconnect(String ip);
+    static void onTelnetInput(String input);
+};
+
+#endif // TELNET_DEBUGGER_H

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -21,9 +21,22 @@ lib_deps =
     paulstoffregen/OneWire@^2.3.8
     milesburton/DallasTemperature@^3.11.0
     bblanchon/ArduinoJson@^7.0.0
+    lennarthennigs/ESP Telnet@^2.2.3
 
 ; Hardware integration test environment - only runs when explicitly selected
 [env:hardware_test]
 extends = env:esp32dev
 ; Run ALL tests including hardware integration
 test_filter = *
+
+; Native test environment - runs on host machine without hardware
+[env:native]
+platform = native
+test_framework = unity
+build_flags = -DUNIT_TEST
+; Don't build main source, only tests
+build_src_filter = -<*>
+lib_deps =
+    throwtheswitch/Unity@^2.6.0
+test_filter = test_native/*
+lib_extra_dirs = lib

--- a/esp32/test/test_native/test_onewire_diagnostics.cpp
+++ b/esp32/test/test_native/test_onewire_diagnostics.cpp
@@ -1,0 +1,150 @@
+#include <unity.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+
+// Include our diagnostic module (pure C++, no Arduino)
+#include <onewire_diagnostics.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+// ==================== Address Formatting Tests ====================
+
+void test_formatAddress_formats_correctly(void) {
+    uint8_t addr[8] = {0x28, 0xFF, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC};
+    char buffer[24];
+
+    OneWireDiagnostics::formatAddress(addr, buffer);
+
+    TEST_ASSERT_EQUAL_STRING("28:FF:12:34:56:78:9A:BC", buffer);
+}
+
+void test_formatAddress_handles_zeros(void) {
+    uint8_t addr[8] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    char buffer[24];
+
+    OneWireDiagnostics::formatAddress(addr, buffer);
+
+    TEST_ASSERT_EQUAL_STRING("00:00:00:00:00:00:00:00", buffer);
+}
+
+void test_formatAddress_handles_all_ff(void) {
+    uint8_t addr[8] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+    char buffer[24];
+
+    OneWireDiagnostics::formatAddress(addr, buffer);
+
+    TEST_ASSERT_EQUAL_STRING("FF:FF:FF:FF:FF:FF:FF:FF", buffer);
+}
+
+// ==================== Temperature Interpretation Tests ====================
+
+void test_isValidTemperature_true_for_normal_temps(void) {
+    TEST_ASSERT_TRUE(OneWireDiagnostics::isValidTemperature(25.0f));
+    TEST_ASSERT_TRUE(OneWireDiagnostics::isValidTemperature(0.0f));
+    TEST_ASSERT_TRUE(OneWireDiagnostics::isValidTemperature(100.0f));
+    TEST_ASSERT_TRUE(OneWireDiagnostics::isValidTemperature(-10.0f));
+}
+
+void test_isValidTemperature_false_for_disconnected(void) {
+    // DEVICE_DISCONNECTED_C is -127.0
+    TEST_ASSERT_FALSE(OneWireDiagnostics::isValidTemperature(-127.0f));
+}
+
+void test_isValidTemperature_false_for_error_values(void) {
+    // 85.0 is the DS18B20 power-on reset value (indicates read before conversion)
+    TEST_ASSERT_FALSE(OneWireDiagnostics::isValidTemperature(85.0f));
+}
+
+void test_getTemperatureStatus_normal(void) {
+    const char* status = OneWireDiagnostics::getTemperatureStatus(25.0f);
+    TEST_ASSERT_EQUAL_STRING("OK", status);
+}
+
+void test_getTemperatureStatus_disconnected(void) {
+    const char* status = OneWireDiagnostics::getTemperatureStatus(-127.0f);
+    TEST_ASSERT_EQUAL_STRING("DISCONNECTED", status);
+}
+
+void test_getTemperatureStatus_power_on_reset(void) {
+    const char* status = OneWireDiagnostics::getTemperatureStatus(85.0f);
+    TEST_ASSERT_EQUAL_STRING("POWER_ON_RESET", status);
+}
+
+// ==================== Family Code Tests ====================
+
+void test_getFamilyName_DS18B20(void) {
+    uint8_t addr[8] = {0x28, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    const char* name = OneWireDiagnostics::getFamilyName(addr);
+    TEST_ASSERT_EQUAL_STRING("DS18B20", name);
+}
+
+void test_getFamilyName_DS18S20(void) {
+    uint8_t addr[8] = {0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    const char* name = OneWireDiagnostics::getFamilyName(addr);
+    TEST_ASSERT_EQUAL_STRING("DS18S20", name);
+}
+
+void test_getFamilyName_DS1822(void) {
+    uint8_t addr[8] = {0x22, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    const char* name = OneWireDiagnostics::getFamilyName(addr);
+    TEST_ASSERT_EQUAL_STRING("DS1822", name);
+}
+
+void test_getFamilyName_unknown(void) {
+    uint8_t addr[8] = {0x99, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+    const char* name = OneWireDiagnostics::getFamilyName(addr);
+    TEST_ASSERT_EQUAL_STRING("UNKNOWN", name);
+}
+
+// ==================== Diagnostic Report Tests ====================
+
+void test_DiagnosticResult_initialized_correctly(void) {
+    DiagnosticResult result;
+    result.deviceCount = 0;
+    result.parasitic = false;
+    result.busState = BUS_STATE_UNKNOWN;
+
+    TEST_ASSERT_EQUAL(0, result.deviceCount);
+    TEST_ASSERT_FALSE(result.parasitic);
+    TEST_ASSERT_EQUAL(BUS_STATE_UNKNOWN, result.busState);
+}
+
+void test_busStateToString_returns_correct_strings(void) {
+    TEST_ASSERT_EQUAL_STRING("OK", OneWireDiagnostics::busStateToString(BUS_STATE_OK));
+    TEST_ASSERT_EQUAL_STRING("NO_DEVICES", OneWireDiagnostics::busStateToString(BUS_STATE_NO_DEVICES));
+    TEST_ASSERT_EQUAL_STRING("SHORT_CIRCUIT", OneWireDiagnostics::busStateToString(BUS_STATE_SHORT));
+    TEST_ASSERT_EQUAL_STRING("UNKNOWN", OneWireDiagnostics::busStateToString(BUS_STATE_UNKNOWN));
+}
+
+// ==================== Main ====================
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+
+    // Address formatting tests
+    RUN_TEST(test_formatAddress_formats_correctly);
+    RUN_TEST(test_formatAddress_handles_zeros);
+    RUN_TEST(test_formatAddress_handles_all_ff);
+
+    // Temperature interpretation tests
+    RUN_TEST(test_isValidTemperature_true_for_normal_temps);
+    RUN_TEST(test_isValidTemperature_false_for_disconnected);
+    RUN_TEST(test_isValidTemperature_false_for_error_values);
+    RUN_TEST(test_getTemperatureStatus_normal);
+    RUN_TEST(test_getTemperatureStatus_disconnected);
+    RUN_TEST(test_getTemperatureStatus_power_on_reset);
+
+    // Family code tests
+    RUN_TEST(test_getFamilyName_DS18B20);
+    RUN_TEST(test_getFamilyName_DS18S20);
+    RUN_TEST(test_getFamilyName_DS1822);
+    RUN_TEST(test_getFamilyName_unknown);
+
+    // Diagnostic result tests
+    RUN_TEST(test_DiagnosticResult_initialized_correctly);
+    RUN_TEST(test_busStateToString_returns_correct_strings);
+
+    return UNITY_END();
+}

--- a/esp32/test_probes_baseline.txt
+++ b/esp32/test_probes_baseline.txt
@@ -1,0 +1,56 @@
+# Baseline diagnostic capture - Known Good Test Probes
+# Captured: 2026-01-07T14:33:57-08:00
+# Purpose: Compare against problematic hot tub probe
+
+=================================
+ESP32 Hot Tub Diagnostic Console
+=================================
+Type 'help' for commands
+
+
+========== FULL DIAGNOSTICS ==========
+
+--- Connection Info ---
+WiFi SSID: misuse
+IP Address: 10.21.11.148
+Signal Strength: -35 dBm
+Uptime: 227 seconds
+
+--- Hardware Config ---
+OneWire Pin: GPIO4
+
+--- OneWire Bus Scan ---
+Bus State: Presence pulse detected (OK)
+Power Mode: PARASITIC (2-wire)
+Devices Found: 2
+
+--- Device Details ---
+
+Device 0:
+  Address: 28:F6:DD:87:00:88:1E:E8
+  Family: DS18B20 (0x28)
+  Resolution: 12 bits
+  CRC: Valid
+
+Device 1:
+  Address: 28:D5:AA:87:00:23:16:34
+  Family: DS18B20 (0x28)
+  Resolution: 12 bits
+  CRC: Valid
+
+--- Sensor Readings ---
+Requesting temperatures...
+Conversion time: 492 ms
+
+Sensor 0 (28:F6:DD:87:00:88:1E:E8):
+  Temperature: 18.81 C / 65.86 F
+  Status: OK
+
+Sensor 1 (28:D5:AA:87:00:23:16:34):
+  Temperature: 18.19 C / 64.74 F
+  Status: OK
+
+
+========== END DIAGNOSTICS ==========
+
+

--- a/frontend/e2e/sensor-config.spec.ts
+++ b/frontend/e2e/sensor-config.spec.ts
@@ -1,0 +1,184 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E tests for the ESP32 Sensor Configuration panel.
+ * Tests sensor role assignment and persistence.
+ */
+
+test.describe('ESP32 Sensor Configuration Panel', () => {
+	test.beforeEach(async ({ page }) => {
+		// Login as admin (required to see sensor config panel)
+		await page.goto('/tub/login');
+		await page.fill('#username', 'admin');
+		await page.fill('#password', 'password');
+		await page.click('button[type="submit"]');
+		await expect(page.getByRole('heading', { name: 'Schedule', exact: true })).toBeVisible({ timeout: 10000 });
+	});
+
+	test.describe('Panel Display', () => {
+		test('displays ESP32 Sensor Configuration header for admin', async ({ page }) => {
+			await expect(page.getByRole('heading', { name: 'ESP32 Sensor Configuration' })).toBeVisible({ timeout: 10000 });
+		});
+
+		test('displays detected sensors from ESP32', async ({ page }) => {
+			// Wait for sensors to load
+			const sensorPanel = page.locator('text=ESP32 Sensor Configuration').locator('..');
+			await expect(sensorPanel).toBeVisible({ timeout: 10000 });
+
+			// Should show at least one sensor with its address (hex format)
+			// Sensor addresses look like "28:F6:DD:87:00:88:1E:E8"
+			await expect(page.locator('text=/28:[A-F0-9]{2}:[A-F0-9]{2}/').first()).toBeVisible({ timeout: 10000 });
+		});
+
+		test('displays role dropdown for each sensor', async ({ page }) => {
+			// Wait for sensor config panel to load
+			await expect(page.getByRole('heading', { name: 'ESP32 Sensor Configuration' })).toBeVisible({ timeout: 10000 });
+
+			// Should have at least one role dropdown
+			const roleSelect = page.locator('select').filter({ hasText: /Water Temperature|Ambient Temperature|Unassigned/ }).first();
+			await expect(roleSelect).toBeVisible({ timeout: 10000 });
+		});
+	});
+
+	test.describe('Role Assignment', () => {
+		test('can change sensor role from dropdown', async ({ page }) => {
+			// Wait for sensor config panel to load
+			await expect(page.getByRole('heading', { name: 'ESP32 Sensor Configuration' })).toBeVisible({ timeout: 10000 });
+
+			// Find role dropdown by looking for selects that have 'water' option (unique to sensor config)
+			const roleSelect = page.locator('select:has(option[value="water"])').first();
+			await expect(roleSelect).toBeVisible({ timeout: 10000 });
+
+			// Get current value
+			const initialValue = await roleSelect.inputValue();
+
+			// Change to a different value
+			const newValue = initialValue === 'water' ? 'ambient' : 'water';
+			await roleSelect.selectOption(newValue);
+
+			// Wait for save to complete (panel might show loading state)
+			await page.waitForTimeout(1000);
+
+			// Verify the dropdown shows new value
+			await expect(roleSelect).toHaveValue(newValue);
+		});
+
+		test('role change persists after page reload', async ({ page }) => {
+			// Wait for sensor config panel to load
+			await expect(page.getByRole('heading', { name: 'ESP32 Sensor Configuration' })).toBeVisible({ timeout: 10000 });
+
+			// Find role dropdown by looking for selects that have 'water' option
+			const roleSelect = page.locator('select:has(option[value="water"])').first();
+			await expect(roleSelect).toBeVisible({ timeout: 10000 });
+
+			// Get current value and pick a different one
+			const initialValue = await roleSelect.inputValue();
+			const newValue = initialValue === 'unassigned' ? 'water' : 'unassigned';
+
+			// Change the role
+			await roleSelect.selectOption(newValue);
+
+			// Wait for save to complete (watch for network request)
+			await page.waitForResponse(response =>
+				response.url().includes('/api/esp32/sensors/') &&
+				response.request().method() === 'PUT'
+			);
+
+			// Small delay for UI to update
+			await page.waitForTimeout(500);
+
+			// Verify value changed in UI before reload
+			await expect(roleSelect).toHaveValue(newValue);
+
+			// Set up wait for sensors response BEFORE reload
+			const sensorsResponsePromise = page.waitForResponse(response =>
+				response.url().includes('/api/esp32/sensors') &&
+				response.request().method() === 'GET'
+			);
+
+			// Reload the page
+			await page.reload();
+
+			// Wait for sensors response
+			await sensorsResponsePromise;
+
+			// Wait for page and sensor config to load
+			await expect(page.getByRole('heading', { name: 'ESP32 Sensor Configuration' })).toBeVisible({ timeout: 10000 });
+
+			// Find role dropdown after reload
+			const roleSelectAfterReload = page.locator('select:has(option[value="water"])').first();
+			await expect(roleSelectAfterReload).toBeVisible({ timeout: 10000 });
+
+			// Role should persist after reload
+			await expect(roleSelectAfterReload).toHaveValue(newValue);
+
+			// Restore original value for cleanup
+			await roleSelectAfterReload.selectOption(initialValue);
+			await page.waitForTimeout(1000);
+		});
+	});
+
+	test.describe('Role Change Network Request', () => {
+		test('changing role sends PUT request to backend', async ({ page }) => {
+			// Wait for sensor config panel to load
+			await expect(page.getByRole('heading', { name: 'ESP32 Sensor Configuration' })).toBeVisible({ timeout: 10000 });
+
+			// Set up request listener
+			const requestPromise = page.waitForRequest(request =>
+				request.url().includes('/api/esp32/sensors/') &&
+				request.method() === 'PUT'
+			);
+
+			// Find role dropdown by looking for selects that have 'water' option
+			const roleSelect = page.locator('select:has(option[value="water"])').first();
+			await expect(roleSelect).toBeVisible({ timeout: 10000 });
+
+			// Get current value and change to something different
+			const initialValue = await roleSelect.inputValue();
+			const newValue = initialValue === 'water' ? 'ambient' : 'water';
+
+			// Change the role
+			await roleSelect.selectOption(newValue);
+
+			// Wait for the PUT request
+			const request = await requestPromise;
+
+			// Verify request was made correctly
+			expect(request.method()).toBe('PUT');
+			expect(request.url()).toContain('/api/esp32/sensors/');
+
+			// Verify request body contains the role
+			const postData = request.postDataJSON();
+			expect(postData).toHaveProperty('role', newValue);
+		});
+
+		test('backend returns success for role update', async ({ page }) => {
+			// Wait for sensor config panel to load
+			await expect(page.getByRole('heading', { name: 'ESP32 Sensor Configuration' })).toBeVisible({ timeout: 10000 });
+
+			// Set up response listener
+			const responsePromise = page.waitForResponse(response =>
+				response.url().includes('/api/esp32/sensors/') &&
+				response.request().method() === 'PUT'
+			);
+
+			// Find role dropdown by looking for selects that have 'water' option
+			const roleSelect = page.locator('select:has(option[value="water"])').first();
+			const initialValue = await roleSelect.inputValue();
+			const newValue = initialValue === 'water' ? 'ambient' : 'water';
+
+			// Change the role
+			await roleSelect.selectOption(newValue);
+
+			// Wait for the response
+			const response = await responsePromise;
+
+			// Verify response is successful
+			expect(response.status()).toBe(200);
+
+			const responseBody = await response.json();
+			expect(responseBody).toHaveProperty('sensor');
+			expect(responseBody.sensor).toHaveProperty('role', newValue);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- **ESP32 Telnet Debugger**: Remote diagnostics via port 23 for field debugging without USB access
  - Commands: `diag`, `scan`, `read`, `info`, `help`
  - Shows OneWire bus state, device enumeration, CRC validation, temperature readings
  
- **Router URL-decode fix**: Sensor role changes now persist correctly
  - Browser URL-encodes colons in sensor addresses (28:F6:DD → 28%3AF6%3ADD)
  - Router now properly decodes route parameters
  
- **E2E Tests**: New sensor-config.spec.ts with 7 tests for admin panel

## Test plan

- [x] Backend unit tests pass (568 tests)
- [x] E2E sensor config tests pass (7 tests)
- [x] ESP32 native tests pass (15 tests)
- [ ] Deploy and verify sensor role assignment works in production UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)