### PR TITLE
Fix sensor role exclusivity - only one sensor per role

### DIFF
--- a/backend/tests/Services/Esp32SensorConfigServiceTest.php
+++ b/backend/tests/Services/Esp32SensorConfigServiceTest.php
@@ -183,6 +183,35 @@ class Esp32SensorConfigServiceTest extends TestCase
 
     /**
      * @test
+     * This test reproduces a bug where assigning a role to a new sensor
+     * doesn't clear the role from the old sensor, causing getSensorByRole
+     * to return the wrong (old) sensor address.
+     */
+    public function setSensorRoleClearsPreviousRoleFromOtherSensors(): void
+    {
+        $oldSensor = '28:AA:AA:AA:AA:AA:AA:AA';
+        $newSensor = '28:BB:BB:BB:BB:BB:BB:BB';
+
+        // Old sensor has water role
+        $this->service->setSensorRole($oldSensor, 'water');
+        $this->assertEquals('water', $this->service->getSensorConfig($oldSensor)['role']);
+        $this->assertEquals($oldSensor, $this->service->getSensorByRole('water'));
+
+        // Assign water role to new sensor
+        $this->service->setSensorRole($newSensor, 'water');
+
+        // New sensor should have water role
+        $this->assertEquals('water', $this->service->getSensorConfig($newSensor)['role']);
+
+        // Old sensor should NO LONGER have water role (should be unassigned)
+        $this->assertEquals('unassigned', $this->service->getSensorConfig($oldSensor)['role']);
+
+        // getSensorByRole should return the NEW sensor
+        $this->assertEquals($newSensor, $this->service->getSensorByRole('water'));
+    }
+
+    /**
+     * @test
      */
     public function getSensorByRoleReturnsCorrectSensor(): void
     {


### PR DESCRIPTION
## Summary

Fixes bug where assigning a role to a new sensor didn't clear the role from the old sensor, causing the temperature display to show null for water temp.

**Root cause:** When user assigns `water` role to new sensor, the old sensor still had `water` role. `getSensorByRole('water')` returned the old sensor (first iteration match), but old sensor wasn't in current readings → water temp was null.

**Fix:** Roles are now exclusive. Assigning a role clears it from any other sensor.

## Test plan

- [x] New unit test `setSensorRoleClearsPreviousRoleFromOtherSensors` passes
- [x] All 569 backend tests pass
- [x] All 7 E2E sensor config tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)