### PR TITLE
Add dynamic ESP32 polling interval based on heater status

### DIFF
--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -109,7 +109,7 @@ $temperatureStateService = new TemperatureStateService($temperatureStateFile);
 // (must be created before TemperatureController so we can inject it)
 $esp32TemperatureFile = __DIR__ . '/../storage/state/esp32-temperature.json';
 $esp32ConfigFile = __DIR__ . '/../storage/state/esp32-sensor-config.json';
-$esp32TemperatureService = new Esp32TemperatureService($esp32TemperatureFile);
+$esp32TemperatureService = new Esp32TemperatureService($esp32TemperatureFile, $equipmentStatusService);
 $esp32SensorConfigService = new Esp32SensorConfigService($esp32ConfigFile);
 $esp32CalibratedService = new Esp32CalibratedTemperatureService($esp32TemperatureService, $esp32SensorConfigService);
 $esp32ApiKey = $config['ESP32_API_KEY'] ?? '';

--- a/backend/tests/Services/Esp32TemperatureServiceTest.php
+++ b/backend/tests/Services/Esp32TemperatureServiceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use HotTub\Services\Esp32TemperatureService;
+use HotTub\Services\EquipmentStatusService;
+
+/**
+ * Unit tests for Esp32TemperatureService.
+ */
+class Esp32TemperatureServiceTest extends TestCase
+{
+    private string $storageFile;
+    private string $equipmentStatusFile;
+    private EquipmentStatusService $equipmentStatus;
+
+    protected function setUp(): void
+    {
+        $this->storageFile = sys_get_temp_dir() . '/test_esp32_temp_' . uniqid() . '.json';
+        $this->equipmentStatusFile = sys_get_temp_dir() . '/test_equipment_status_' . uniqid() . '.json';
+        $this->equipmentStatus = new EquipmentStatusService($this->equipmentStatusFile);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->storageFile)) {
+            unlink($this->storageFile);
+        }
+        if (file_exists($this->equipmentStatusFile)) {
+            unlink($this->equipmentStatusFile);
+        }
+    }
+
+    // ==================== Dynamic Interval Tests ====================
+
+    /**
+     * @test
+     * When heater is ON, ESP32 should poll every 60 seconds for faster temperature updates.
+     */
+    public function getIntervalReturns60WhenHeaterIsOn(): void
+    {
+        $this->equipmentStatus->setHeaterOn();
+
+        $service = new Esp32TemperatureService($this->storageFile, $this->equipmentStatus);
+
+        $this->assertEquals(60, $service->getInterval());
+    }
+
+    /**
+     * @test
+     * When heater is OFF, ESP32 should poll at the default 5-minute interval.
+     */
+    public function getIntervalReturns300WhenHeaterIsOff(): void
+    {
+        // Heater starts off by default, but let's be explicit
+        $this->equipmentStatus->setHeaterOff();
+
+        $service = new Esp32TemperatureService($this->storageFile, $this->equipmentStatus);
+
+        $this->assertEquals(300, $service->getInterval());
+    }
+
+    /**
+     * @test
+     * When no EquipmentStatusService is provided, fallback to default interval.
+     * This ensures backward compatibility.
+     */
+    public function getIntervalReturnsDefaultWhenNoEquipmentStatusService(): void
+    {
+        $service = new Esp32TemperatureService($this->storageFile);
+
+        $this->assertEquals(300, $service->getInterval());
+    }
+}


### PR DESCRIPTION
## Summary
- When heater is ON, ESP32 polls every 60 seconds for faster temperature updates during heating cycles
- When heater is OFF, uses default 5-minute interval
- Backward compatible - existing code without EquipmentStatusService still works

## Changes
- Add `HEATING_INTERVAL` constant (60s) to `Esp32TemperatureService`
- Inject `EquipmentStatusService` to check heater state
- Update `getInterval()` to return dynamic interval
- Add unit tests for all interval scenarios

## Test plan
- [x] Unit tests pass for heater ON (60s interval)
- [x] Unit tests pass for heater OFF (300s interval)
- [x] Unit tests pass for fallback when no equipment service (backward compat)
- [x] Full backend test suite passes (572 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)