### PR TITLE
Fix cookie path scoping to prevent cross-app login conflicts

### DIFF
--- a/backend/src/Services/CookieHelper.php
+++ b/backend/src/Services/CookieHelper.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Services;
+
+/**
+ * Helper for generating cookie options with proper path scoping.
+ *
+ * This class ensures auth cookies are scoped to the deployment path,
+ * preventing conflicts when multiple apps share the same domain.
+ *
+ * Example: On misuse.org, movie-night at /dinner-and-a-movie and
+ * hot-tub-controller at /tub each need their own cookie scope.
+ *
+ * The cookie path is derived automatically from the deployment structure,
+ * not configured manually, ensuring it always matches the actual deploy path.
+ */
+class CookieHelper
+{
+    private const COOKIE_NAME = 'auth_token';
+    private const BACKEND_SUFFIX = '/backend/public';
+
+    private string $cookiePath;
+
+    /**
+     * @param string $cookiePath The base path for cookie scoping (e.g., /tub)
+     */
+    public function __construct(string $cookiePath = '/')
+    {
+        $this->cookiePath = $cookiePath;
+    }
+
+    /**
+     * Derive the app base path from the current request's SCRIPT_NAME.
+     *
+     * Our codebase convention places index.php at ./backend/public/index.php.
+     * This method strips that known suffix from the deployment path to get
+     * the app's root URL path.
+     *
+     * Examples:
+     *   /dinner-and-a-movie/backend/public -> /dinner-and-a-movie
+     *   /tub/backend/public -> /tub
+     *   /apps/tub/backend/public -> /apps/tub
+     *   / (dev server at root) -> /
+     */
+    public static function deriveAppBasePath(): string
+    {
+        $scriptDir = dirname($_SERVER['SCRIPT_NAME'] ?? '/index.php');
+
+        // Strip the known /backend/public suffix to get the app root
+        if (str_ends_with($scriptDir, self::BACKEND_SUFFIX)) {
+            $basePath = substr($scriptDir, 0, -strlen(self::BACKEND_SUFFIX));
+            return $basePath === '' ? '/' : $basePath;
+        }
+
+        // Development or non-standard deployment: default to root
+        // (In dev, apps run on different ports so root path is fine)
+        return '/';
+    }
+
+    /**
+     * Get cookie name for auth token.
+     */
+    public function getCookieName(): string
+    {
+        return self::COOKIE_NAME;
+    }
+
+    /**
+     * Get cookie options for setting an auth token.
+     *
+     * @param string $token The JWT token value
+     * @param int $expirySeconds Seconds until expiry
+     * @return array<string, mixed> Options array for setcookie()
+     */
+    public function getAuthCookieOptions(string $token, int $expirySeconds): array
+    {
+        return [
+            'expires' => time() + $expirySeconds,
+            'path' => $this->cookiePath,
+            'httponly' => true,
+            'samesite' => 'Lax',
+            'secure' => isset($_SERVER['HTTPS']),
+        ];
+    }
+
+    /**
+     * Get cookie options for clearing the auth token.
+     *
+     * @return array<string, mixed> Options array for setcookie()
+     */
+    public function getClearCookieOptions(): array
+    {
+        return [
+            'expires' => time() - 3600,
+            'path' => $this->cookiePath,
+            'httponly' => true,
+            'samesite' => 'Lax',
+            'secure' => isset($_SERVER['HTTPS']),
+        ];
+    }
+
+    /**
+     * Get the configured cookie path.
+     */
+    public function getCookiePath(): string
+    {
+        return $this->cookiePath;
+    }
+}

--- a/backend/tests/Services/CookieHelperTest.php
+++ b/backend/tests/Services/CookieHelperTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+use HotTub\Services\CookieHelper;
+
+/**
+ * Tests for CookieHelper - ensures cookies are scoped correctly per deployment.
+ *
+ * Bug context: When multiple apps (movie-night and hot-tub-controller) are deployed
+ * on the same domain (misuse.org) at different paths (/dinner-and-a-movie and /tub),
+ * they were both setting auth_token cookies at path="/", causing login conflicts.
+ * Logging into one app would overwrite the other app's cookie.
+ *
+ * Solution: Each app derives its cookie path from its deployment location by
+ * stripping the known /backend/public suffix from SCRIPT_NAME.
+ */
+class CookieHelperTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        // Clean up any SCRIPT_NAME we set during tests
+        unset($_SERVER['SCRIPT_NAME']);
+    }
+
+    // =========================================================================
+    // Tests for deriveAppBasePath()
+    // =========================================================================
+
+    public function testDeriveAppBasePathForProductionTub(): void
+    {
+        $_SERVER['SCRIPT_NAME'] = '/tub/backend/public/index.php';
+
+        $path = CookieHelper::deriveAppBasePath();
+
+        $this->assertEquals('/tub', $path);
+    }
+
+    public function testDeriveAppBasePathForProductionMovieNight(): void
+    {
+        $_SERVER['SCRIPT_NAME'] = '/dinner-and-a-movie/backend/public/index.php';
+
+        $path = CookieHelper::deriveAppBasePath();
+
+        $this->assertEquals('/dinner-and-a-movie', $path);
+    }
+
+    public function testDeriveAppBasePathForNestedDeployment(): void
+    {
+        $_SERVER['SCRIPT_NAME'] = '/apps/my-app/backend/public/index.php';
+
+        $path = CookieHelper::deriveAppBasePath();
+
+        $this->assertEquals('/apps/my-app', $path);
+    }
+
+    public function testDeriveAppBasePathForRootDeployment(): void
+    {
+        // When deployed directly at domain root (e.g., app.example.com)
+        $_SERVER['SCRIPT_NAME'] = '/backend/public/index.php';
+
+        $path = CookieHelper::deriveAppBasePath();
+
+        $this->assertEquals('/', $path);
+    }
+
+    public function testDeriveAppBasePathForDevServer(): void
+    {
+        // php -S localhost:8080 -t public sets SCRIPT_NAME to /index.php
+        $_SERVER['SCRIPT_NAME'] = '/index.php';
+
+        $path = CookieHelper::deriveAppBasePath();
+
+        $this->assertEquals('/', $path);
+    }
+
+    public function testDeriveAppBasePathWithNoScriptName(): void
+    {
+        unset($_SERVER['SCRIPT_NAME']);
+
+        $path = CookieHelper::deriveAppBasePath();
+
+        $this->assertEquals('/', $path);
+    }
+
+    // =========================================================================
+    // Tests for cookie options
+    // =========================================================================
+
+    public function testGetAuthCookieOptionsUsesProvidedPath(): void
+    {
+        $helper = new CookieHelper('/tub');
+
+        $options = $helper->getAuthCookieOptions('test-token', 3600);
+
+        $this->assertEquals('/tub', $options['path']);
+    }
+
+    public function testGetAuthCookieOptionsDefaultsToRoot(): void
+    {
+        $helper = new CookieHelper();
+
+        $options = $helper->getAuthCookieOptions('test-token', 3600);
+
+        $this->assertEquals('/', $options['path']);
+    }
+
+    public function testGetAuthCookieOptionsIncludesSecuritySettings(): void
+    {
+        $helper = new CookieHelper('/app');
+
+        $options = $helper->getAuthCookieOptions('test-token', 3600);
+
+        $this->assertTrue($options['httponly']);
+        $this->assertEquals('Lax', $options['samesite']);
+    }
+
+    public function testGetAuthCookieOptionsCalculatesExpiry(): void
+    {
+        $helper = new CookieHelper();
+
+        $beforeTime = time();
+        $options = $helper->getAuthCookieOptions('test-token', 3600);
+        $afterTime = time();
+
+        $this->assertGreaterThanOrEqual($beforeTime + 3600, $options['expires']);
+        $this->assertLessThanOrEqual($afterTime + 3600, $options['expires']);
+    }
+
+    public function testGetClearCookieOptionsUsesProvidedPath(): void
+    {
+        $helper = new CookieHelper('/tub');
+
+        $options = $helper->getClearCookieOptions();
+
+        $this->assertEquals('/tub', $options['path']);
+    }
+
+    public function testGetClearCookieOptionsHasExpiredTimestamp(): void
+    {
+        $helper = new CookieHelper();
+
+        $options = $helper->getClearCookieOptions();
+
+        $this->assertLessThan(time(), $options['expires']);
+    }
+
+    public function testGetCookieName(): void
+    {
+        $helper = new CookieHelper();
+
+        $this->assertEquals('auth_token', $helper->getCookieName());
+    }
+
+    public function testGetCookiePath(): void
+    {
+        $helper = new CookieHelper('/my-app');
+
+        $this->assertEquals('/my-app', $helper->getCookiePath());
+    }
+}


### PR DESCRIPTION
## Summary
- Adds CookieHelper class that derives cookie path automatically from deployment location
- Strips known `/backend/public` suffix from SCRIPT_NAME to get app root path
- Prevents cookie conflicts when multiple apps share the same domain (misuse.org)

**Note:** This PR also includes pending target temperature feature work.

## Test plan
- [x] All 626 backend tests pass
- [ ] Verify login works on production after deploy
- [ ] Verify logging into hot-tub-controller doesn't log you out of movie-night

🤖 Generated with [Claude Code](https://claude.com/claude-code)