### PR TITLE
Fix Heat to Target scheduling bugs

### DIFF
--- a/frontend/src/lib/components/SchedulePanel.svelte
+++ b/frontend/src/lib/components/SchedulePanel.svelte
@@ -42,8 +42,7 @@
 	const actions = [
 		{ value: 'heater-on', label: 'Heater ON' },
 		{ value: 'heater-off', label: 'Heater OFF' },
-		{ value: 'pump-run', label: 'Run Pump' },
-		{ value: 'heat-to-target', label: 'Heat to Target' }
+		{ value: 'pump-run', label: 'Run Pump' }
 	];
 
 	// Set default date/time to tomorrow at 6:00 AM
@@ -318,8 +317,16 @@
 	const recurringJobs = $derived(jobs.filter((j) => j.recurring));
 	const oneOffJobs = $derived(jobs.filter((j) => !j.recurring));
 
+	// Map for displaying job actions (includes heat-to-target for existing jobs)
+	const actionDisplayLabels: Record<string, string> = {
+		'heater-on': 'Heater ON',
+		'heater-off': 'Heater OFF',
+		'pump-run': 'Run Pump',
+		'heat-to-target': 'Heat to Target'
+	};
+
 	function getActionLabel(action: string): string {
-		return actions.find((a) => a.value === action)?.label ?? action;
+		return actionDisplayLabels[action] ?? action;
 	}
 
 	function getJobDisplayLabel(job: ScheduledJob): string {

--- a/frontend/src/lib/components/SchedulePanel.test.ts
+++ b/frontend/src/lib/components/SchedulePanel.test.ts
@@ -842,3 +842,39 @@ describe('SchedulePanel manual refresh button', () => {
 		vi.useRealTimers();
 	});
 });
+
+describe('SchedulePanel action dropdown', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.clearAllMocks();
+		vi.mocked(api.listScheduledJobs).mockResolvedValue({ jobs: [] });
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('does not include heat-to-target as a dropdown option', async () => {
+		// Bug #1: The "Heat to Target" dropdown option is broken because it doesn't
+		// include the required target_temp_f parameter. When target temp is enabled,
+		// "Heater ON" automatically becomes "heat-to-target" with the temp included.
+		// Therefore, "Heat to Target" should not be a separate dropdown option.
+		render(SchedulePanel);
+
+		await waitFor(() => {
+			expect(screen.getByLabelText(/action/i)).toBeTruthy();
+		});
+
+		const actionSelect = screen.getByLabelText(/action/i);
+		const options = actionSelect.querySelectorAll('option');
+		const optionValues = Array.from(options).map((opt) => opt.value);
+		const optionLabels = Array.from(options).map((opt) => opt.textContent);
+
+		// Should have 3 options: heater-on, heater-off, pump-run
+		expect(optionValues).toEqual(['heater-on', 'heater-off', 'pump-run']);
+		expect(optionLabels).toEqual(['Heater ON', 'Heater OFF', 'Run Pump']);
+
+		// Should NOT include heat-to-target
+		expect(optionValues).not.toContain('heat-to-target');
+	});
+});


### PR DESCRIPTION
## Summary
- Remove erroneous "Heat to Target" dropdown option that caused scheduling failures
- Fix recurring heat-to-target jobs to store target temperature params for display

## Test plan
- [x] Backend tests pass (575 tests)
- [x] Frontend tests pass (156 tests)
- [x] Verified "Heat to Target" not in dropdown options
- [x] Verified recurring jobs store params correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)