### PR TITLE
Fix firmware download URL path

### DIFF
--- a/backend/public/api/esp32/temperature/index.php
+++ b/backend/public/api/esp32/temperature/index.php
@@ -51,6 +51,10 @@ if ($apiBaseUrl === null) {
     $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
     $apiBaseUrl = $protocol . '://' . $host . '/api';
 }
+// Ensure API base URL ends with /api (for proper firmware download URL)
+if (!preg_match('#/api$#', $apiBaseUrl)) {
+    $apiBaseUrl = rtrim($apiBaseUrl, '/') . '/api';
+}
 
 // Create handler
 $handler = new Esp32ThinHandler(


### PR DESCRIPTION
## Summary
- Fixes firmware download URL to include `/api` path segment
- The API_BASE_URL in production was missing the /api suffix, causing 404 errors on firmware downloads

## Test plan
- [x] All 596 tests pass
- [ ] Verify firmware download URL is correct after deployment
- [ ] ESP32 should auto-update via HTTP OTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)