### PR TITLE
Fix firmware download path

### DIFF
--- a/backend/public/api/esp32/firmware/download/index.php
+++ b/backend/public/api/esp32/firmware/download/index.php
@@ -14,7 +14,7 @@
 declare(strict_types=1);
 
 // Configuration paths (relative to backend root)
-$backendRoot = __DIR__ . '/../../../..';
+$backendRoot = __DIR__ . '/../../../../..';
 $envFile = $backendRoot . '/.env';
 $firmwareConfigFile = $backendRoot . '/storage/firmware/config.json';
 $firmwareDir = $backendRoot . '/storage/firmware';


### PR DESCRIPTION
## Summary
- Fixes relative path to backend root after moving to download/index.php

## Test plan
- [x] All 596 tests pass
- [ ] Verify firmware download works

🤖 Generated with [Claude Code](https://claude.com/claude-code)