### PR TITLE
Add trailing slash to firmware download URL

### DIFF
--- a/backend/src/Services/Esp32FirmwareService.php
+++ b/backend/src/Services/Esp32FirmwareService.php
@@ -98,7 +98,7 @@ class Esp32FirmwareService
         }
 
         $version = $this->getCurrentVersion();
-        $url = rtrim($baseUrl, '/') . '/esp32/firmware/download';
+        $url = rtrim($baseUrl, '/') . '/esp32/firmware/download/';
 
         return [
             'firmware_version' => $version,

--- a/backend/src/Services/Esp32ThinHandler.php
+++ b/backend/src/Services/Esp32ThinHandler.php
@@ -221,8 +221,8 @@ class Esp32ThinHandler
             return [];
         }
 
-        // Build download URL
-        $downloadUrl = rtrim($this->apiBaseUrl ?? '', '/') . '/esp32/firmware/download';
+        // Build download URL (trailing slash required for directory index)
+        $downloadUrl = rtrim($this->apiBaseUrl ?? '', '/') . '/esp32/firmware/download/';
 
         return [
             'firmware_version' => $config['version'],

--- a/backend/tests/Services/Esp32FirmwareServiceTest.php
+++ b/backend/tests/Services/Esp32FirmwareServiceTest.php
@@ -176,7 +176,7 @@ class Esp32FirmwareServiceTest extends TestCase
         $info = $service->getFirmwareInfoForApi('1.0.0', 'https://example.com/api');
 
         $this->assertEquals('1.2.0', $info['firmware_version']);
-        $this->assertEquals('https://example.com/api/esp32/firmware/download', $info['firmware_url']);
+        $this->assertEquals('https://example.com/api/esp32/firmware/download/', $info['firmware_url']);
     }
 
     public function testGetFirmwareInfoForApiReturnsEmptyWhenFirmwareFileMissing(): void

--- a/backend/tests/Services/Esp32ThinHandlerTest.php
+++ b/backend/tests/Services/Esp32ThinHandlerTest.php
@@ -525,7 +525,7 @@ class Esp32ThinHandlerTest extends TestCase
 
         $this->assertEquals(200, $result['status']);
         $this->assertEquals('2.0.0', $result['body']['firmware_version']);
-        $this->assertEquals('https://example.com/api/esp32/firmware/download', $result['body']['firmware_url']);
+        $this->assertEquals('https://example.com/api/esp32/firmware/download/', $result['body']['firmware_url']);
 
         // Cleanup
         @unlink($firmwareDir . '/firmware.bin');


### PR DESCRIPTION
## Summary
- Adds trailing slash to firmware download URL to avoid 301 redirect
- ESP32 HTTPUpdate may not follow redirects properly

## Test plan
- [x] All 596 tests pass
- [ ] Verify ESP32 successfully downloads and installs firmware

🤖 Generated with [Claude Code](https://claude.com/claude-code)