### PR TITLE
Add CI/CD test gate and RED tests for heat-to-target bugs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to cPanel
+name: Test and Deploy to cPanel
 
 on:
   push:
@@ -6,10 +6,208 @@ on:
   workflow_dispatch:  # Allow manual trigger
 
 jobs:
+  # Find the PR that triggered this push (for commenting and label checks)
+  find-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.find.outputs.pr_number }}
+      skip_tests: ${{ steps.check-label.outputs.skip_tests }}
+    steps:
+      - name: Find associated PR
+        id: find
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Find PRs that were merged with this commit
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 10
+            });
+
+            const mergedPr = prs.find(pr => pr.merge_commit_sha === context.sha);
+
+            if (mergedPr) {
+              console.log(`Found PR #${mergedPr.number}: ${mergedPr.title}`);
+              core.setOutput('pr_number', mergedPr.number);
+            } else {
+              console.log('No associated PR found (manual push or workflow_dispatch)');
+              core.setOutput('pr_number', '');
+            }
+
+      - name: Check for skip-tests label
+        id: check-label
+        if: steps.find.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: ${{ steps.find.outputs.pr_number }}
+            });
+
+            const skipLabel = pr.labels.find(l =>
+              l.name.toLowerCase().includes('skip') &&
+              l.name.toLowerCase().includes('test')
+            );
+
+            if (skipLabel) {
+              console.log(`Found skip label: ${skipLabel.name}`);
+              core.setOutput('skip_tests', 'true');
+            } else {
+              console.log('No skip-tests label found');
+              core.setOutput('skip_tests', 'false');
+            }
+
+  # Run the full test suite
+  test:
+    runs-on: ubuntu-latest
+    needs: find-pr
+    outputs:
+      status: ${{ steps.test-result.outputs.status }}
+    steps:
+      - name: Comment - Tests Starting
+        if: needs.find-pr.outputs.pr_number != '' && needs.find-pr.outputs.skip_tests != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.find-pr.outputs.pr_number }},
+              body: '🧪 **Tests Starting**\n\nRunning full pre-production test suite (`composer test:all`)...\n\n[View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+            });
+
+      - name: Comment - Tests Skipped
+        if: needs.find-pr.outputs.pr_number != '' && needs.find-pr.outputs.skip_tests == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.find-pr.outputs.pr_number }},
+              body: '⚠️ **Tests SKIPPED**\n\nPre-production tests were skipped due to skip-tests label.\n\n**This deployment is proceeding without test verification.**'
+            });
+
+      - name: Skip tests (label present)
+        if: needs.find-pr.outputs.skip_tests == 'true'
+        id: skip-tests
+        run: |
+          echo "Tests skipped due to label"
+          echo "status=skipped" >> $GITHUB_OUTPUT
+
+      - name: Checkout code
+        if: needs.find-pr.outputs.skip_tests != 'true'
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        if: needs.find-pr.outputs.skip_tests != 'true'
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer:v2
+
+      - name: Install backend dependencies
+        if: needs.find-pr.outputs.skip_tests != 'true'
+        run: |
+          cd backend
+          composer install
+
+      - name: Create test .env
+        if: needs.find-pr.outputs.skip_tests != 'true'
+        run: |
+          cat > backend/.env << 'EOF'
+          APP_ENV=testing
+          EXTERNAL_API_MODE=stub
+          JWT_SECRET=ci-test-secret-key
+          JWT_EXPIRY_HOURS=1
+          AUTH_ADMIN_USERNAME=admin
+          AUTH_ADMIN_PASSWORD=password
+          HEALTHCHECKS_IO_KEY=${{ secrets.HEALTHCHECKS_IO_KEY }}
+          EOF
+
+      - name: Run pre-production tests
+        if: needs.find-pr.outputs.skip_tests != 'true'
+        id: run-tests
+        run: |
+          cd backend
+          composer test:all 2>&1 | tee test-output.txt
+          TEST_EXIT_CODE=${PIPESTATUS[0]}
+          echo "exit_code=$TEST_EXIT_CODE" >> $GITHUB_OUTPUT
+          exit $TEST_EXIT_CODE
+
+      - name: Capture test output
+        if: needs.find-pr.outputs.skip_tests != 'true' && always()
+        id: capture-output
+        run: |
+          if [ -f backend/test-output.txt ]; then
+            # Truncate to last 50 lines for comment
+            LAST_OUTPUT=$(tail -50 backend/test-output.txt)
+            # Escape for GitHub Actions
+            echo "output<<EOF" >> $GITHUB_OUTPUT
+            echo "$LAST_OUTPUT" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set test result
+        id: test-result
+        if: always()
+        run: |
+          if [ "${{ needs.find-pr.outputs.skip_tests }}" == "true" ]; then
+            echo "status=skipped" >> $GITHUB_OUTPUT
+          elif [ "${{ steps.run-tests.outputs.exit_code }}" == "0" ]; then
+            echo "status=passed" >> $GITHUB_OUTPUT
+          else
+            echo "status=failed" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment - Tests Passed
+        if: needs.find-pr.outputs.pr_number != '' && needs.find-pr.outputs.skip_tests != 'true' && steps.run-tests.outputs.exit_code == '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.find-pr.outputs.pr_number }},
+              body: '✅ **Tests Passed**\n\nAll pre-production tests passed. Proceeding to deployment.\n\n```\n${{ steps.capture-output.outputs.output }}\n```'
+            });
+
+      - name: Comment - Tests Failed
+        if: needs.find-pr.outputs.pr_number != '' && needs.find-pr.outputs.skip_tests != 'true' && failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.find-pr.outputs.pr_number }},
+              body: '❌ **Tests Failed**\n\n**Deployment blocked.** Fix the failing tests and merge again.\n\n```\n${{ steps.capture-output.outputs.output }}\n```\n\n[View full test output](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+            });
+
+  # Deploy only if tests passed (or were skipped with label)
   deploy:
     runs-on: ubuntu-latest
-
+    needs: [find-pr, test]
+    if: needs.test.outputs.status == 'passed' || needs.test.outputs.status == 'skipped'
     steps:
+      - name: Comment - Deployment Starting
+        if: needs.find-pr.outputs.pr_number != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.find-pr.outputs.pr_number }},
+              body: '🚀 **Deployment Starting**\n\nDeploying to production server...'
+            });
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -165,3 +363,27 @@ jobs:
           fi
 
           echo "Cron health setup completed successfully"
+
+      - name: Comment - Deployment Complete
+        if: needs.find-pr.outputs.pr_number != '' && success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.find-pr.outputs.pr_number }},
+              body: '✅ **Deployment Complete**\n\nSuccessfully deployed to production.\n\n- Commit: `${{ github.sha }}`\n- Build: #${{ github.run_number }}'
+            });
+
+      - name: Comment - Deployment Failed
+        if: needs.find-pr.outputs.pr_number != '' && failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ needs.find-pr.outputs.pr_number }},
+              body: '❌ **Deployment Failed**\n\nDeployment encountered an error. Check the workflow logs for details.\n\n[View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+            });

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,47 @@ cd backend && composer cleanup:healthchecks
 - If you find yourself on `production`, switch to `main` before making changes
 - The `production` branch represents what's deployed to the live server
 
+## CI/CD Pipeline
+
+The GitHub Actions workflow (`.github/workflows/deploy.yml`) automatically tests and deploys code when PRs are merged to `production`.
+
+### Pipeline Flow
+
+1. **PR merged to production** → Workflow triggers
+2. **Find PR** → Locates the merged PR for commenting and label checks
+3. **Run Tests** → Executes `composer test:all` (full pre-production suite)
+4. **Deploy** → Only runs if tests pass (or are skipped via label)
+
+### PR Comments
+
+The workflow comments on the PR at each stage:
+- 🧪 **Tests Starting** - With link to workflow run
+- ✅ **Tests Passed** - With test output summary
+- ❌ **Tests Failed** - With failure details, blocks deployment
+- 🚀 **Deployment Starting**
+- ✅ **Deployment Complete** - With commit SHA and build number
+- ❌ **Deployment Failed** - With link to logs
+
+### Emergency Skip Tests Label
+
+To skip tests in emergencies, add a label containing both "skip" and "test" (case-insensitive):
+
+**Recommended label name:** `⚠️ SKIP-TESTS-EMERGENCY-ONLY`
+
+This label should be:
+- Scary enough to discourage casual use
+- Created in GitHub repo settings before first use
+- Only used for genuine emergencies where deployment is critical
+
+When skip label is present:
+- Tests are skipped entirely
+- PR gets a ⚠️ warning comment
+- Deployment proceeds without verification
+
+### No CI on Main Branch
+
+Pushes to `main` do NOT trigger CI. This keeps the feedback loop fast during development. Tests only run automatically when deploying to production via PR.
+
 ## Production Server Access
 
 **CRITICAL: FTP access is READ-ONLY for debugging. NEVER upload files via FTP.**

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -25,10 +25,12 @@
             "phpunit --group=live",
             "@cleanup:healthchecks"
         ],
-        "test:all": [
+        "test:pre-production": [
             "phpunit --configuration=phpunit-all.xml",
             "@cleanup:healthchecks"
         ],
+        "test:all": "@test:pre-production",
+        "test:e2e-chain": "phpunit --group=pre-production",
         "cleanup:healthchecks": "php scripts/cleanup-test-healthchecks.php --delete",
         "cleanup:healthchecks:dry": "php scripts/cleanup-test-healthchecks.php"
     }

--- a/backend/phpunit-all.xml
+++ b/backend/phpunit-all.xml
@@ -1,7 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    PHPUnit configuration for running ALL tests including live API tests.
-    Use this before pushing to production: composer test:all
+    PHPUnit configuration for PRE-PRODUCTION testing.
+    Runs ALL tests including:
+    - @group live (tests hitting real external APIs like Healthchecks.io)
+    - @group pre-production (E2E chain tests with real servers/scripts)
+
+    Run before pushing to production: composer test:all
+
+    Test hierarchy:
+    - composer test           → Fast daily dev tests (excludes live, pre-production)
+    - composer test:all       → Full pre-production suite (includes everything)
+    - composer test:live      → Just live API tests
+    - composer test:e2e-chain → Just E2E chain tests
 -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -12,6 +12,7 @@
     <groups>
         <exclude>
             <group>live</group>
+            <group>pre-production</group>
         </exclude>
     </groups>
     <php>

--- a/backend/tests/Integration/HeatToTargetCronChainTest.php
+++ b/backend/tests/Integration/HeatToTargetCronChainTest.php
@@ -1,0 +1,535 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Tests\Integration;
+
+use HotTub\Services\CrontabAdapter;
+use HotTub\Services\EquipmentStatusService;
+use HotTub\Services\Esp32TemperatureService;
+use HotTub\Services\SchedulerService;
+use HotTub\Services\TargetTemperatureService;
+use HotTub\Tests\Fixtures\HeatingCycleFixture;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the heat-to-target cron chain.
+ *
+ * These tests verify the FULL production flow and were created to catch bugs where:
+ *
+ * BUG #1: start() saves state but never initiates heating or schedules a check
+ * BUG #2: scheduleNextCheck() creates curl commands without Authorization headers
+ *
+ * The tests are designed to FAIL (RED) until the bugs are fixed.
+ * Run before fixing to verify they correctly identify the bugs.
+ *
+ * @group integration
+ */
+class HeatToTargetCronChainTest extends TestCase
+{
+    private string $testDir;
+    private string $jobsDir;
+    private string $stateDir;
+    private string $logsDir;
+    private string $envFile;
+    private string $equipmentStatusFile;
+    private string $esp32TempFile;
+    private string $targetTempFile;
+    private CrontabAdapter $crontab;
+    private EquipmentStatusService $equipmentStatus;
+    private Esp32TemperatureService $esp32Temp;
+    private HeatingCycleFixture $fixture;
+
+    /** @var array<string> Cron entries we added (for cleanup) */
+    private array $addedCronPatterns = [];
+
+    /** @var array<string> Job files we created (for cleanup) */
+    private array $createdJobFiles = [];
+
+    protected function setUp(): void
+    {
+        // Create isolated test directories
+        $this->testDir = sys_get_temp_dir() . '/heat-target-chain-test-' . uniqid();
+        $this->jobsDir = $this->testDir . '/scheduled-jobs';
+        $this->stateDir = $this->testDir . '/state';
+        $this->logsDir = $this->testDir . '/logs';
+
+        mkdir($this->jobsDir, 0755, true);
+        mkdir($this->stateDir, 0755, true);
+        mkdir($this->logsDir, 0755, true);
+
+        // Set up state files
+        $this->equipmentStatusFile = $this->stateDir . '/equipment-status.json';
+        $this->esp32TempFile = $this->stateDir . '/esp32-temperature.json';
+        $this->targetTempFile = $this->stateDir . '/target-temperature.json';
+
+        // Create minimal .env for cron-runner
+        $this->envFile = $this->testDir . '/.env';
+        file_put_contents($this->envFile, "CRON_JWT=test-jwt-token\nEXTERNAL_API_MODE=stub\n");
+
+        // Set up services
+        $this->crontab = new CrontabAdapter();
+        $this->equipmentStatus = new EquipmentStatusService($this->equipmentStatusFile);
+        $this->esp32Temp = new Esp32TemperatureService($this->esp32TempFile, $this->equipmentStatus);
+
+        // Load fixture for temperature data
+        $this->fixture = HeatingCycleFixture::load();
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up crontab entries we added
+        foreach ($this->addedCronPatterns as $pattern) {
+            $this->crontab->removeByPattern($pattern);
+        }
+
+        // Clean up job files
+        foreach ($this->createdJobFiles as $file) {
+            if (file_exists($file)) {
+                unlink($file);
+            }
+        }
+
+        // Clean up test directory
+        $this->recursiveDelete($this->testDir);
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $files = array_diff(scandir($dir), ['.', '..']);
+        foreach ($files as $file) {
+            $path = "$dir/$file";
+            is_dir($path) ? $this->recursiveDelete($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Store a temperature reading in the ESP32 temp file.
+     */
+    private function storeTemperatureReading(float $tempF): void
+    {
+        $reading = $this->fixture->getReading(0); // Use fixture structure
+        $apiRequest = $this->fixture->toApiRequest($reading);
+
+        // Override the temperature
+        $tempC = ($tempF - 32) * 5 / 9;
+        $apiRequest['sensors'][0]['temp_c'] = $tempC;
+
+        $this->esp32Temp->store($apiRequest);
+    }
+
+    /**
+     * Create a TargetTemperatureService with recording mocks.
+     *
+     * @return array{service: TargetTemperatureService, iftttCalls: array<string>, cronEntries: array<string>}
+     */
+    private function createServiceWithRecorders(): array
+    {
+        $iftttCalls = [];
+        $mockIfttt = $this->createMock(\HotTub\Contracts\IftttClientInterface::class);
+        $mockIfttt->method('trigger')->willReturnCallback(function ($event) use (&$iftttCalls) {
+            $iftttCalls[] = $event;
+            return true;
+        });
+
+        $cronEntries = [];
+        $mockCrontab = $this->createMock(\HotTub\Contracts\CrontabAdapterInterface::class);
+        $mockCrontab->method('addEntry')->willReturnCallback(function ($entry) use (&$cronEntries) {
+            $cronEntries[] = $entry;
+        });
+
+        $service = new TargetTemperatureService(
+            $this->targetTempFile,
+            $mockIfttt,
+            $this->equipmentStatus,
+            $this->esp32Temp,
+            $mockCrontab,
+            '/path/to/cron-runner.sh',
+            'https://example.com/api'
+        );
+
+        return [
+            'service' => $service,
+            'iftttCalls' => &$iftttCalls,
+            'cronEntries' => &$cronEntries,
+        ];
+    }
+
+    // =========================================================================
+    // BUG #1: start() doesn't initiate heating or schedule a check
+    // =========================================================================
+
+    /**
+     * @test
+     * BUG #1 - RED TEST: After calling start(), the heater should turn on
+     * OR a temperature check should be scheduled. Currently NEITHER happens.
+     *
+     * This test MUST FAIL until Bug #1 is fixed.
+     */
+    public function bug1_startShouldInitiateHeatingWhenTempBelowTarget(): void
+    {
+        // Set up temperature well below target
+        $this->storeTemperatureReading(82.0); // Target will be 101°F
+
+        $recorder = $this->createServiceWithRecorders();
+        $service = $recorder['service'];
+        $iftttCalls = &$recorder['iftttCalls'];
+        $cronEntries = &$recorder['cronEntries'];
+
+        // Call start() - this is what happens when the API endpoint is called
+        $service->start(101.0);
+
+        // Verify state was saved (this part works)
+        $state = $service->getState();
+        $this->assertTrue($state['active'], 'State should be active');
+        $this->assertEquals(101.0, $state['target_temp_f'], 'Target temp should be saved');
+
+        // THE BUG: After start(), one of these MUST happen:
+        // Option A: Heater turns on immediately (temp is below target)
+        $heaterTurnedOn = in_array('hot-tub-heat-on', $iftttCalls);
+
+        // Option B: A cron job is scheduled to check temperature
+        $checkScheduled = !empty($cronEntries);
+
+        $this->assertTrue(
+            $heaterTurnedOn || $checkScheduled,
+            "BUG #1: After start() with temp 82°F < target 101°F:\n" .
+            "- Heater turned on: " . ($heaterTurnedOn ? 'YES' : 'NO') . "\n" .
+            "- Check scheduled: " . ($checkScheduled ? 'YES' : 'NO') . "\n" .
+            "At least one must happen, but neither does!"
+        );
+    }
+
+    /**
+     * @test
+     * BUG #1 - RED TEST: Equipment status should reflect heater state after start().
+     *
+     * This test MUST FAIL until Bug #1 is fixed.
+     */
+    public function bug1_equipmentStatusShouldShowHeaterOnAfterStart(): void
+    {
+        $this->storeTemperatureReading(82.0);
+
+        $recorder = $this->createServiceWithRecorders();
+        $service = $recorder['service'];
+
+        // Heater starts off
+        $this->assertFalse($this->equipmentStatus->getStatus()['heater']['on']);
+
+        // Call start()
+        $service->start(101.0);
+
+        // THE BUG: Heater should be on now (temp 82°F is below target 101°F)
+        $this->assertTrue(
+            $this->equipmentStatus->getStatus()['heater']['on'],
+            "BUG #1: After start() with temp below target, heater should be ON"
+        );
+    }
+
+    // =========================================================================
+    // BUG #2: scheduleNextCheck() creates curl without Authorization header
+    // =========================================================================
+
+    /**
+     * @test
+     * BUG #2 - RED TEST: The cron entry created by scheduleNextCheck() must
+     * include an Authorization header, otherwise it will fail with 401.
+     *
+     * This test MUST FAIL until Bug #2 is fixed.
+     */
+    public function bug2_scheduledCronEntryShouldIncludeAuthorizationHeader(): void
+    {
+        $this->storeTemperatureReading(82.0);
+
+        $cronEntries = [];
+        $mockCrontab = $this->createMock(\HotTub\Contracts\CrontabAdapterInterface::class);
+        $mockCrontab->method('addEntry')->willReturnCallback(function ($entry) use (&$cronEntries) {
+            $cronEntries[] = $entry;
+        });
+
+        $mockIfttt = $this->createMock(\HotTub\Contracts\IftttClientInterface::class);
+        $mockIfttt->method('trigger')->willReturn(true);
+
+        $service = new TargetTemperatureService(
+            $this->targetTempFile,
+            $mockIfttt,
+            $this->equipmentStatus,
+            $this->esp32Temp,
+            $mockCrontab,
+            '/path/to/cron-runner.sh',
+            'https://example.com/api'
+        );
+
+        // Set up active state and call checkAndAdjust to trigger cron scheduling
+        $service->start(101.0);
+        $service->checkAndAdjust(); // This schedules the next check
+
+        // Verify a cron entry was created
+        $this->assertNotEmpty($cronEntries, 'A cron entry should be scheduled');
+
+        $cronEntry = $cronEntries[0];
+
+        // THE BUG: The cron entry uses raw curl without Authorization header
+        // It should either:
+        // A) Include -H 'Authorization: Bearer <token>'
+        // B) Use cron-runner.sh which handles auth automatically
+        $hasAuthHeader = str_contains($cronEntry, 'Authorization');
+        $usesCronRunner = str_contains($cronEntry, 'cron-runner.sh');
+
+        $this->assertTrue(
+            $hasAuthHeader || $usesCronRunner,
+            "BUG #2: Scheduled cron entry lacks authentication:\n" .
+            "Entry: $cronEntry\n\n" .
+            "The /api/maintenance/heat-target-check endpoint requires auth.\n" .
+            "The cron entry must either:\n" .
+            "- Include Authorization header: " . ($hasAuthHeader ? 'YES' : 'NO') . "\n" .
+            "- Use cron-runner.sh (which handles auth): " . ($usesCronRunner ? 'YES' : 'NO')
+        );
+    }
+
+    /**
+     * @test
+     * BUG #2 - RED TEST: Verify the endpoint path is correct in scheduled cron.
+     * The heat-target-check endpoint should include /api prefix.
+     */
+    public function bug2_scheduledCronShouldCallCorrectEndpoint(): void
+    {
+        $this->storeTemperatureReading(82.0);
+
+        $cronEntries = [];
+        $mockCrontab = $this->createMock(\HotTub\Contracts\CrontabAdapterInterface::class);
+        $mockCrontab->method('addEntry')->willReturnCallback(function ($entry) use (&$cronEntries) {
+            $cronEntries[] = $entry;
+        });
+
+        $mockIfttt = $this->createMock(\HotTub\Contracts\IftttClientInterface::class);
+        $mockIfttt->method('trigger')->willReturn(true);
+
+        $service = new TargetTemperatureService(
+            $this->targetTempFile,
+            $mockIfttt,
+            $this->equipmentStatus,
+            $this->esp32Temp,
+            $mockCrontab,
+            '/path/to/cron-runner.sh',
+            'https://example.com/api'
+        );
+
+        $service->start(101.0);
+        $service->checkAndAdjust();
+
+        $this->assertNotEmpty($cronEntries);
+        $cronEntry = $cronEntries[0];
+
+        // Verify the endpoint includes /api prefix
+        $this->assertStringContainsString(
+            '/api/maintenance/heat-target-check',
+            $cronEntry,
+            "Cron entry should call /api/maintenance/heat-target-check"
+        );
+    }
+
+    // =========================================================================
+    // CHAIN VERIFICATION: Full flow tests (will pass after bugs are fixed)
+    // =========================================================================
+
+    /**
+     * @test
+     * CHAIN TEST: Scheduling heat-to-target via SchedulerService creates proper job file.
+     * This part currently WORKS - the scheduling infrastructure is fine.
+     */
+    public function chain_schedulerCreatesProperJobFileWithParams(): void
+    {
+        $scheduledTime = (new \DateTime('+5 minutes'))->format(\DateTime::ATOM);
+
+        $scheduler = new SchedulerService(
+            $this->jobsDir,
+            '/path/to/cron-runner.sh',
+            'https://example.com/api',
+            $this->crontab
+        );
+
+        $result = $scheduler->scheduleJob('heat-to-target', $scheduledTime, false, [
+            'target_temp_f' => 101.0,
+        ]);
+
+        // Track for cleanup
+        $this->addedCronPatterns[] = 'HOTTUB:' . $result['jobId'];
+
+        // Verify job file contents
+        $jobFile = $this->jobsDir . '/' . $result['jobId'] . '.json';
+        $this->assertFileExists($jobFile);
+
+        $jobData = json_decode(file_get_contents($jobFile), true);
+        $this->assertEquals('/api/equipment/heat-to-target', $jobData['endpoint']);
+        $this->assertEquals(['target_temp_f' => 101.0], $jobData['params']);
+        $this->assertEquals('https://example.com/api', $jobData['apiBaseUrl']);
+    }
+
+    /**
+     * @test
+     * CHAIN TEST: checkAndAdjust() works correctly when called manually.
+     * This part currently WORKS - the issue is it's never called automatically.
+     */
+    public function chain_checkAndAdjustWorksWhenCalledManually(): void
+    {
+        $this->storeTemperatureReading(82.0);
+
+        $recorder = $this->createServiceWithRecorders();
+        $service = $recorder['service'];
+        $iftttCalls = &$recorder['iftttCalls'];
+        $cronEntries = &$recorder['cronEntries'];
+
+        // Manually set up state (what start() does)
+        $service->start(101.0);
+
+        // Manually call checkAndAdjust (what SHOULD happen automatically)
+        $result = $service->checkAndAdjust();
+
+        // Verify it works
+        $this->assertTrue($result['heater_turned_on']);
+        $this->assertContains('hot-tub-heat-on', $iftttCalls);
+        $this->assertTrue($result['cron_scheduled']);
+        $this->assertNotEmpty($cronEntries);
+    }
+
+    /**
+     * @test
+     * CHAIN TEST: Full heating cycle completes when checkAndAdjust is called repeatedly.
+     * This demonstrates the feature WORKS if properly orchestrated.
+     */
+    public function chain_fullHeatingCycleWorksWithManualOrchestration(): void
+    {
+        $recorder = $this->createServiceWithRecorders();
+        $service = $recorder['service'];
+        $iftttCalls = &$recorder['iftttCalls'];
+
+        $mockCrontab = $this->createMock(\HotTub\Contracts\CrontabAdapterInterface::class);
+        $mockCrontab->method('addEntry');
+        $mockCrontab->method('removeByPattern');
+
+        // Start at 82°F, target 101°F
+        $this->storeTemperatureReading(82.0);
+        $service->start(101.0);
+        $service->checkAndAdjust(); // Manual orchestration
+
+        $this->assertContains('hot-tub-heat-on', $iftttCalls);
+
+        // Simulate heating progress
+        $this->storeTemperatureReading(95.0);
+        $result = $service->checkAndAdjust();
+        $this->assertTrue($result['heating']);
+        $this->assertArrayNotHasKey('target_reached', $result, 'Should still be heating');
+
+        // Reach target
+        $this->storeTemperatureReading(101.0);
+        $result = $service->checkAndAdjust();
+        $this->assertTrue($result['target_reached']);
+        $this->assertContains('hot-tub-heat-off', $iftttCalls);
+        $this->assertFalse($service->getState()['active']);
+    }
+
+    // =========================================================================
+    // DOCUMENTATION: These tests PASS but document the broken behavior
+    // =========================================================================
+
+    /**
+     * @test
+     * DOCUMENTATION: Shows exactly what happens (and doesn't happen) after start().
+     * This test PASSES because it asserts the CURRENT (broken) behavior.
+     */
+    public function documentation_whatActuallyHappensAfterStart(): void
+    {
+        $this->storeTemperatureReading(82.0);
+
+        $recorder = $this->createServiceWithRecorders();
+        $service = $recorder['service'];
+        $iftttCalls = &$recorder['iftttCalls'];
+        $cronEntries = &$recorder['cronEntries'];
+
+        // Before start()
+        $this->assertFalse($this->equipmentStatus->getStatus()['heater']['on']);
+
+        // Call start()
+        $service->start(101.0);
+
+        // Document what DOES happen (state is saved)
+        $this->assertTrue($service->getState()['active'], 'State IS saved');
+        $this->assertEquals(101.0, $service->getState()['target_temp_f']);
+
+        // Document what DOESN'T happen (these assertions PASS because nothing happens)
+        $this->assertEmpty($iftttCalls, 'IFTTT is NOT called - heater stays off');
+        $this->assertEmpty($cronEntries, 'No cron is scheduled');
+        $this->assertFalse(
+            $this->equipmentStatus->getStatus()['heater']['on'],
+            'Heater is still OFF despite temp being below target'
+        );
+
+        // This is the bug in action: user expects heating to start, but nothing happens
+    }
+
+    /**
+     * @test
+     * DOCUMENTATION: Shows the curl command created by scheduleNextCheck() lacks auth.
+     * This test PASSES because it documents the CURRENT (broken) behavior.
+     */
+    public function documentation_cronEntryLacksAuthentication(): void
+    {
+        $this->storeTemperatureReading(82.0);
+
+        $cronEntries = [];
+        $mockCrontab = $this->createMock(\HotTub\Contracts\CrontabAdapterInterface::class);
+        $mockCrontab->method('addEntry')->willReturnCallback(function ($entry) use (&$cronEntries) {
+            $cronEntries[] = $entry;
+        });
+
+        $mockIfttt = $this->createMock(\HotTub\Contracts\IftttClientInterface::class);
+        $mockIfttt->method('trigger')->willReturn(true);
+
+        $service = new TargetTemperatureService(
+            $this->targetTempFile,
+            $mockIfttt,
+            $this->equipmentStatus,
+            $this->esp32Temp,
+            $mockCrontab,
+            '/path/to/cron-runner.sh',
+            'https://example.com/api'
+        );
+
+        $service->start(101.0);
+        $service->checkAndAdjust();
+
+        $this->assertNotEmpty($cronEntries);
+        $cronEntry = $cronEntries[0];
+
+        // Document the broken curl command
+        $this->assertStringContainsString('curl', $cronEntry, 'Uses curl directly');
+        $this->assertStringNotContainsString('Authorization', $cronEntry, 'NO auth header');
+        $this->assertStringNotContainsString('cron-runner.sh', $cronEntry, 'Does NOT use cron-runner.sh');
+
+        // The curl command looks like:
+        // curl -s -X POST 'https://example.com/api/maintenance/heat-target-check' -H 'Content-Type: application/json'
+        // Missing: -H 'Authorization: Bearer <token>'
+    }
+
+    // =========================================================================
+    // SLOW TEST: Real cron timing (optional, requires waiting)
+    // =========================================================================
+
+    /**
+     * @test
+     * @group slow
+     * SLOW TEST: Full chain with real cron timing.
+     * Requires waiting ~60 seconds for cron to fire.
+     */
+    public function slow_fullCronChainWithRealTiming(): void
+    {
+        $this->markTestSkipped(
+            'Slow test requiring cron timing. Run with: vendor/bin/phpunit --group slow'
+        );
+    }
+}

--- a/backend/tests/PreProduction/HeatToTargetE2ETest.php
+++ b/backend/tests/PreProduction/HeatToTargetE2ETest.php
@@ -1,0 +1,512 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Tests\PreProduction;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * End-to-end pre-production tests for the heat-to-target feature.
+ *
+ * These tests run the FULL chain:
+ * 1. Start a real PHP dev server
+ * 2. Set up temperature data via real HTTP calls
+ * 3. Schedule heat-to-target via the API
+ * 4. Execute cron-runner.sh (simulating cron firing)
+ * 5. Verify IFTTT stub was called
+ * 6. Verify next cron is scheduled
+ * 7. Execute that cron
+ * 8. Verify the chain continues
+ *
+ * Run before pushing to production:
+ *   composer test:all           # Full pre-production suite
+ *   composer test:e2e-chain     # Just these E2E tests
+ *
+ * @group pre-production
+ */
+class HeatToTargetE2ETest extends TestCase
+{
+    private const SERVER_HOST = '127.0.0.1';
+    private const SERVER_PORT = 8089;
+    private const SERVER_START_TIMEOUT = 5;
+
+    private string $backendDir;
+    private string $storageDir;
+    private string $envFile;
+    private string $envBackup;
+    private ?int $serverPid = null;
+
+    /** @var resource|null */
+    private $serverProcess = null;
+
+    protected function setUp(): void
+    {
+        $this->backendDir = dirname(__DIR__, 2);
+        $this->storageDir = $this->backendDir . '/storage';
+        $this->envFile = $this->backendDir . '/.env';
+        $this->envBackup = $this->backendDir . '/.env.e2e-backup';
+
+        // Backup existing .env if present
+        if (file_exists($this->envFile)) {
+            copy($this->envFile, $this->envBackup);
+        }
+
+        // Create test .env with stub mode and test JWT
+        $this->createTestEnv();
+
+        // Clean up any leftover state from previous runs
+        $this->cleanupState();
+
+        // Start the PHP dev server
+        $this->startServer();
+    }
+
+    protected function tearDown(): void
+    {
+        // Stop the server
+        $this->stopServer();
+
+        // Restore original .env
+        if (file_exists($this->envBackup)) {
+            rename($this->envBackup, $this->envFile);
+        } elseif (file_exists($this->envFile)) {
+            unlink($this->envFile);
+        }
+
+        // Clean up test state
+        $this->cleanupState();
+    }
+
+    private function createTestEnv(): void
+    {
+        // Create a long-lived JWT for testing (expires in 1 hour)
+        $header = base64_encode(json_encode(['typ' => 'JWT', 'alg' => 'HS256']));
+        $payload = base64_encode(json_encode([
+            'iat' => time(),
+            'exp' => time() + 3600,
+            'sub' => 'e2e-test',
+            'role' => 'admin',
+        ]));
+        $secret = 'e2e-test-secret-key-for-jwt-signing';
+        $signature = base64_encode(hash_hmac('sha256', "$header.$payload", $secret, true));
+        $jwt = "$header.$payload.$signature";
+
+        $env = <<<ENV
+APP_ENV=testing
+EXTERNAL_API_MODE=stub
+JWT_SECRET=$secret
+JWT_EXPIRY_HOURS=1
+CRON_JWT=$jwt
+AUTH_ADMIN_USERNAME=admin
+AUTH_ADMIN_PASSWORD=password
+ENV;
+
+        file_put_contents($this->envFile, $env);
+    }
+
+    private function cleanupState(): void
+    {
+        // Clean up scheduled jobs
+        $jobsDir = $this->storageDir . '/scheduled-jobs';
+        if (is_dir($jobsDir)) {
+            foreach (glob("$jobsDir/heat-target-*.json") as $file) {
+                unlink($file);
+            }
+        }
+
+        // Clean up state files
+        $stateDir = $this->storageDir . '/state';
+        foreach (['target-temperature.json', 'equipment-status.json'] as $file) {
+            $path = "$stateDir/$file";
+            if (file_exists($path)) {
+                unlink($path);
+            }
+        }
+
+        // Clean up crontab entries
+        $this->cleanupCrontab();
+    }
+
+    private function cleanupCrontab(): void
+    {
+        $crontab = shell_exec('crontab -l 2>/dev/null') ?? '';
+        if (empty(trim($crontab))) {
+            return;
+        }
+
+        $lines = explode("\n", $crontab);
+        $filtered = array_filter($lines, fn($line) => !str_contains($line, 'HOTTUB:heat-target'));
+
+        if (count($filtered) !== count($lines)) {
+            $newCrontab = implode("\n", $filtered);
+            $tempFile = tempnam(sys_get_temp_dir(), 'crontab');
+            file_put_contents($tempFile, $newCrontab);
+            shell_exec("crontab $tempFile 2>/dev/null");
+            unlink($tempFile);
+        }
+    }
+
+    private function startServer(): void
+    {
+        $host = self::SERVER_HOST;
+        $port = self::SERVER_PORT;
+        $docroot = $this->backendDir . '/public';
+        $router = $docroot . '/router.php';
+
+        // Start PHP built-in server with router script for proper URL rewriting
+        $cmd = sprintf(
+            'php -S %s:%d -t %s %s > /dev/null 2>&1 & echo $!',
+            $host,
+            $port,
+            escapeshellarg($docroot),
+            escapeshellarg($router)
+        );
+
+        $this->serverPid = (int) trim(shell_exec($cmd));
+
+        // Wait for server to be ready
+        $startTime = time();
+        while (time() - $startTime < self::SERVER_START_TIMEOUT) {
+            $socket = @fsockopen($host, $port, $errno, $errstr, 1);
+            if ($socket) {
+                fclose($socket);
+                return;
+            }
+            usleep(100000); // 100ms
+        }
+
+        $this->fail("Failed to start PHP dev server on $host:$port");
+    }
+
+    private function stopServer(): void
+    {
+        if ($this->serverPid) {
+            shell_exec("kill {$this->serverPid} 2>/dev/null");
+            $this->serverPid = null;
+        }
+    }
+
+    private function getApiBaseUrl(): string
+    {
+        return sprintf('http://%s:%d', self::SERVER_HOST, self::SERVER_PORT);
+    }
+
+    /**
+     * Make an HTTP request to the test server.
+     *
+     * @return array{status: int, body: array}
+     */
+    private function httpRequest(string $method, string $endpoint, ?array $body = null, ?string $authToken = null): array
+    {
+        $url = $this->getApiBaseUrl() . $endpoint;
+
+        $opts = [
+            'http' => [
+                'method' => $method,
+                'header' => "Content-Type: application/json\r\n",
+                'timeout' => 10,
+                'ignore_errors' => true,
+            ],
+        ];
+
+        if ($authToken) {
+            $opts['http']['header'] .= "Authorization: Bearer $authToken\r\n";
+        }
+
+        if ($body !== null) {
+            $opts['http']['content'] = json_encode($body);
+        }
+
+        $context = stream_context_create($opts);
+        $response = @file_get_contents($url, false, $context);
+
+        // Parse status code from headers
+        $status = 500;
+        if (isset($http_response_header[0])) {
+            preg_match('/HTTP\/\d\.\d\s+(\d+)/', $http_response_header[0], $matches);
+            $status = (int) ($matches[1] ?? 500);
+        }
+
+        return [
+            'status' => $status,
+            'body' => json_decode($response ?: '{}', true) ?? [],
+        ];
+    }
+
+    /**
+     * Get the CRON_JWT from the test .env file.
+     */
+    private function getCronJwt(): string
+    {
+        $env = file_get_contents($this->envFile);
+        preg_match('/CRON_JWT=(.+)/', $env, $matches);
+        return $matches[1] ?? '';
+    }
+
+    /**
+     * Store temperature data via the ESP32 endpoint.
+     */
+    private function storeTemperature(float $tempF): void
+    {
+        $tempC = ($tempF - 32) * 5 / 9;
+
+        // Read ESP32 API key from env or use a test key
+        // For testing, we'll write directly to the state file
+        $stateFile = $this->storageDir . '/state/esp32-temperature.json';
+        $stateDir = dirname($stateFile);
+
+        if (!is_dir($stateDir)) {
+            mkdir($stateDir, 0755, true);
+        }
+
+        $data = [
+            'device_id' => 'E2E:TEST:DEVICE',
+            'sensors' => [
+                [
+                    'address' => '28:E2:E2:TE:ST:00:00:01',
+                    'temp_c' => $tempC,
+                    'temp_f' => $tempF,
+                ],
+            ],
+            'uptime_seconds' => 3600,
+            'timestamp' => (new \DateTime())->format('c'),
+            'received_at' => time(),
+            'temp_c' => $tempC,
+            'temp_f' => $tempF,
+        ];
+
+        file_put_contents($stateFile, json_encode($data, JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * Read the equipment status from the state file.
+     */
+    private function getEquipmentStatus(): array
+    {
+        $file = $this->storageDir . '/state/equipment-status.json';
+        if (!file_exists($file)) {
+            return ['heater' => ['on' => false], 'pump' => ['on' => false]];
+        }
+        return json_decode(file_get_contents($file), true) ?? [];
+    }
+
+    /**
+     * Read the target temperature state.
+     */
+    private function getTargetTempState(): array
+    {
+        $file = $this->storageDir . '/state/target-temperature.json';
+        if (!file_exists($file)) {
+            return ['active' => false];
+        }
+        return json_decode(file_get_contents($file), true) ?? [];
+    }
+
+    /**
+     * Get crontab entries matching a pattern.
+     */
+    private function getCrontabEntries(string $pattern): array
+    {
+        $crontab = shell_exec('crontab -l 2>/dev/null') ?? '';
+        $lines = explode("\n", $crontab);
+        return array_values(array_filter($lines, fn($line) => str_contains($line, $pattern)));
+    }
+
+    // =========================================================================
+    // E2E TESTS
+    // =========================================================================
+
+    /**
+     * @test
+     * E2E RED TEST: Full chain from API call to heater turning on.
+     *
+     * This test calls the heat-to-target API endpoint and verifies that:
+     * 1. The target state is set
+     * 2. The heater turns on (or a check is scheduled)
+     * 3. Equipment status reflects the heater state
+     *
+     * THIS TEST SHOULD FAIL until Bug #1 is fixed.
+     */
+    public function e2e_heatToTargetApiShouldTurnOnHeater(): void
+    {
+        // Set up temperature below target
+        $this->storeTemperature(82.0);
+
+        // Get auth token
+        $cronJwt = $this->getCronJwt();
+        $this->assertNotEmpty($cronJwt, 'CRON_JWT should be set');
+
+        // Call the heat-to-target API (what the scheduled cron job does)
+        $response = $this->httpRequest(
+            'POST',
+            '/api/equipment/heat-to-target',
+            ['target_temp_f' => 101.0],
+            $cronJwt
+        );
+
+        // API should return 200
+        $this->assertEquals(200, $response['status'], 'API should return 200');
+
+        // Target state should be active
+        $targetState = $this->getTargetTempState();
+        $this->assertTrue($targetState['active'] ?? false, 'Target heating should be active');
+        $this->assertEquals(101.0, $targetState['target_temp_f'] ?? 0);
+
+        // THE BUG: Heater should be ON now (temp 82°F is below target 101°F)
+        $equipmentStatus = $this->getEquipmentStatus();
+        $this->assertTrue(
+            $equipmentStatus['heater']['on'] ?? false,
+            "E2E BUG #1: After calling /api/equipment/heat-to-target with temp 82°F < target 101°F,\n" .
+            "the heater should be ON but it is OFF.\n" .
+            "Equipment status: " . json_encode($equipmentStatus)
+        );
+    }
+
+    /**
+     * @test
+     * E2E RED TEST: Scheduled check cron should be able to call the check endpoint.
+     *
+     * After heat-to-target sets up the heating, checkAndAdjust should schedule
+     * a cron that can successfully call /api/maintenance/heat-target-check.
+     *
+     * THIS TEST SHOULD FAIL until Bug #2 is fixed (cron lacks auth).
+     */
+    public function e2e_scheduledCheckCronShouldSuccessfullyCallApi(): void
+    {
+        $this->storeTemperature(82.0);
+        $cronJwt = $this->getCronJwt();
+
+        // First, manually trigger checkAndAdjust by calling the check endpoint
+        // (simulating what SHOULD happen after start() is fixed)
+
+        // Set up the target state manually (since start() doesn't call checkAndAdjust)
+        $targetStateFile = $this->storageDir . '/state/target-temperature.json';
+        $stateDir = dirname($targetStateFile);
+        if (!is_dir($stateDir)) {
+            mkdir($stateDir, 0755, true);
+        }
+        file_put_contents($targetStateFile, json_encode([
+            'active' => true,
+            'target_temp_f' => 101.0,
+            'started_at' => (new \DateTime())->format('c'),
+        ], JSON_PRETTY_PRINT));
+
+        // Call heat-target-check (what the scheduled cron would do)
+        $response = $this->httpRequest(
+            'POST',
+            '/api/maintenance/heat-target-check',
+            [],
+            $cronJwt
+        );
+
+        // This should work with auth
+        $this->assertEquals(
+            200,
+            $response['status'],
+            "heat-target-check should succeed with auth. Got: {$response['status']}"
+        );
+
+        // Now check if a cron was scheduled for the next check
+        $cronEntries = $this->getCrontabEntries('heat-target');
+
+        if (!empty($cronEntries)) {
+            $cronEntry = $cronEntries[0];
+
+            // THE BUG: The cron entry should include auth or use cron-runner.sh
+            $hasAuth = str_contains($cronEntry, 'Authorization');
+            $usesCronRunner = str_contains($cronEntry, 'cron-runner.sh');
+
+            // Check for correct endpoint path (should include /api prefix)
+            $hasCorrectPath = str_contains($cronEntry, '/api/maintenance/heat-target-check');
+            $this->assertTrue(
+                $hasCorrectPath,
+                "E2E BUG #3: Scheduled cron entry has wrong endpoint path:\n" .
+                "Entry: $cronEntry\n\n" .
+                "Should call /api/maintenance/heat-target-check but is missing /api prefix."
+            );
+
+            $this->assertTrue(
+                $hasAuth || $usesCronRunner,
+                "E2E BUG #2: Scheduled cron entry lacks authentication:\n" .
+                "Entry: $cronEntry\n\n" .
+                "Without auth, this cron will fail with 401 when it fires."
+            );
+        }
+    }
+
+    /**
+     * @test
+     * E2E GREEN TEST (after fixes): Full heating cycle via real HTTP and cron simulation.
+     *
+     * This test will pass once both bugs are fixed:
+     * 1. Call /api/equipment/heat-to-target
+     * 2. Verify heater turns on
+     * 3. Simulate temperature reaching target
+     * 4. Call /api/maintenance/heat-target-check
+     * 5. Verify heater turns off and state is cleared
+     */
+    public function e2e_fullHeatingCycleViaHttp(): void
+    {
+        $cronJwt = $this->getCronJwt();
+
+        // Start at 82°F, target 101°F
+        $this->storeTemperature(82.0);
+
+        // Step 1: Call heat-to-target API
+        $response = $this->httpRequest(
+            'POST',
+            '/api/equipment/heat-to-target',
+            ['target_temp_f' => 101.0],
+            $cronJwt
+        );
+        $this->assertEquals(200, $response['status']);
+
+        // Step 2: Verify heater is on (this requires Bug #1 to be fixed)
+        $status = $this->getEquipmentStatus();
+        if (!($status['heater']['on'] ?? false)) {
+            // Bug #1 not fixed yet - manually call checkAndAdjust
+            $this->markTestIncomplete(
+                'Bug #1 not fixed: start() does not call checkAndAdjust(). ' .
+                'Heater is OFF when it should be ON.'
+            );
+        }
+
+        // Step 3: Simulate heating complete - temperature reaches target
+        $this->storeTemperature(101.5);
+
+        // Step 4: Call heat-target-check (simulating cron firing)
+        $response = $this->httpRequest(
+            'POST',
+            '/api/maintenance/heat-target-check',
+            [],
+            $cronJwt
+        );
+        $this->assertEquals(200, $response['status']);
+
+        // Step 5: Verify heater is off and target is cleared
+        $status = $this->getEquipmentStatus();
+        $this->assertFalse(
+            $status['heater']['on'] ?? true,
+            'Heater should be OFF after reaching target'
+        );
+
+        $targetState = $this->getTargetTempState();
+        $this->assertFalse(
+            $targetState['active'] ?? true,
+            'Target heating should be inactive after reaching target'
+        );
+    }
+
+    /**
+     * @test
+     * E2E TEST: Verify server is running and health endpoint works.
+     */
+    public function e2e_serverHealthCheck(): void
+    {
+        $response = $this->httpRequest('GET', '/api/health');
+
+        $this->assertEquals(200, $response['status'], 'Health check should return 200');
+        $this->assertArrayHasKey('status', $response['body']);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds CI/CD pipeline that runs full test suite before deploying to production
- Creates RED tests demonstrating 3 bugs in heat-to-target feature
- Adds `@group pre-production` test category for E2E tests

## What's Included

### CI/CD Pipeline (.github/workflows/deploy.yml)
- **Tests run automatically** when PRs are merged to production
- **Deployment blocked** if tests fail
- **PR comments** show test results at each stage
- **Skip-tests label** available for emergencies (`⚠️ SKIP-TESTS-EMERGENCY-ONLY`)

### RED Tests (Intentionally Failing)
These tests demonstrate bugs that need to be fixed:

| Bug | Test | Issue |
|-----|------|-------|
| #1 | `e2e_heatToTargetApiShouldTurnOnHeater` | `start()` doesn't call `checkAndAdjust()` |
| #2 | `e2e_scheduledCheckCronShouldSuccessfullyCallApi` | Curl command lacks JWT auth |
| #3 | Same test | URL missing `/api` prefix |

### Test Infrastructure
- `composer test` - Fast daily tests (excludes live, pre-production)
- `composer test:all` - Full suite including live + pre-production
- `composer test:e2e-chain` - Just E2E pre-production tests

## Test plan

- [x] Verify workflow syntax is valid
- [ ] Merge this PR and observe CI running tests
- [ ] Verify tests FAIL (blocking deployment) - proves gate works
- [ ] Fix bugs in follow-up PR
- [ ] Verify tests PASS and deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)