### PR TITLE
Fix GitHub Actions permissions for PR comments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,12 @@ on:
     branches: [production]
   workflow_dispatch:  # Allow manual trigger
 
+# Required for commenting on PRs and reading PR labels
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   # Find the PR that triggered this push (for commenting and label checks)
   find-pr:


### PR DESCRIPTION
## Summary

Fixes the permissions error that caused the test job to fail in PR #94.

## Changes

Added `permissions` block to workflow:
```yaml
permissions:
  contents: read
  pull-requests: write
  issues: write
```

## Test plan

- [ ] Merge this PR
- [ ] Verify workflow can now comment on PRs
- [ ] Verify RED tests still fail and block deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)