### PR TITLE
Fix CI test hanging - use composer test instead of test:all

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,7 +85,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: ${{ needs.find-pr.outputs.pr_number }},
-              body: '🧪 **Tests Starting**\n\nRunning full pre-production test suite (`composer test:all`)...\n\n[View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+              body: '🧪 **Tests Starting**\n\nRunning test suite (`composer test`)...\n\n[View workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
             });
 
       - name: Comment - Tests Skipped
@@ -97,7 +97,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: ${{ needs.find-pr.outputs.pr_number }},
-              body: '⚠️ **Tests SKIPPED**\n\nPre-production tests were skipped due to skip-tests label.\n\n**This deployment is proceeding without test verification.**'
+              body: '⚠️ **Tests SKIPPED**\n\nTests were skipped due to skip-tests label.\n\n**This deployment is proceeding without test verification.**'
             });
 
       - name: Skip tests (label present)
@@ -137,12 +137,14 @@ jobs:
           HEALTHCHECKS_IO_KEY=${{ secrets.HEALTHCHECKS_IO_KEY }}
           EOF
 
-      - name: Run pre-production tests
+      - name: Run tests
         if: needs.find-pr.outputs.skip_tests != 'true'
         id: run-tests
         run: |
           cd backend
-          composer test:all 2>&1 | tee test-output.txt
+          # Run standard tests (excludes @group live and @group pre-production)
+          # E2E/live tests are meant for local pre-production validation
+          composer test 2>&1 | tee test-output.txt
           TEST_EXIT_CODE=${PIPESTATUS[0]}
           echo "exit_code=$TEST_EXIT_CODE" >> $GITHUB_OUTPUT
           exit $TEST_EXIT_CODE

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,8 +196,10 @@ The GitHub Actions workflow (`.github/workflows/deploy.yml`) automatically tests
 
 1. **PR merged to production** → Workflow triggers
 2. **Find PR** → Locates the merged PR for commenting and label checks
-3. **Run Tests** → Executes `composer test:all` (full pre-production suite)
+3. **Run Tests** → Executes `composer test` (excludes live/E2E tests)
 4. **Deploy** → Only runs if tests pass (or are skipped via label)
+
+**Note:** E2E tests (`@group pre-production`) and live API tests (`@group live`) are excluded from CI because they require server processes or real API keys. Run `composer test:all` locally before pushing to production.
 
 ### PR Comments
 


### PR DESCRIPTION
## Summary

Fixes the CI test job that was hanging for 13+ minutes.

## Root Cause

The E2E tests (`@group pre-production`) were hanging in CI because they:
- Start a PHP background server process
- Manipulate crontab (not available in GitHub Actions runners)

## Solution

Run `composer test` instead of `composer test:all` in CI. This:
- Excludes `@group live` and `@group pre-production` tests
- Still runs the Integration tests (`HeatToTargetCronChainTest`) which demonstrate the bugs using mocks
- Completes in seconds instead of hanging

## Test plan

- [ ] Merge this PR
- [ ] Verify workflow completes quickly (not 13+ minutes)
- [ ] Verify RED tests fail and block deployment
- [ ] Verify PR gets comments showing test failure

## Test hierarchy reminder

| Command | Runs | Use for |
|---------|------|---------|
| `composer test` | Unit + Integration (mocks) | CI, daily dev |
| `composer test:all` | Everything including E2E | Local pre-production |

🤖 Generated with [Claude Code](https://claude.com/claude-code)