### PR TITLE
Hotfix: Heat-target cleanup and admin cancel UI

### DIFF
--- a/backend/src/Services/TargetTemperatureService.php
+++ b/backend/src/Services/TargetTemperatureService.php
@@ -73,8 +73,28 @@ class TargetTemperatureService
 
     public function stop(): void
     {
+        // Delete the state file
         if (file_exists($this->stateFile)) {
             unlink($this->stateFile);
+        }
+
+        // Clean up any orphaned heat-target job files
+        $this->cleanupJobFiles();
+    }
+
+    /**
+     * Clean up heat-target job files from scheduled-jobs directory.
+     */
+    private function cleanupJobFiles(): void
+    {
+        $jobsDir = dirname(dirname($this->stateFile)) . '/scheduled-jobs';
+        if (!is_dir($jobsDir)) {
+            return;
+        }
+
+        $pattern = $jobsDir . '/' . self::CRON_JOB_PREFIX . '-*.json';
+        foreach (glob($pattern) as $jobFile) {
+            unlink($jobFile);
         }
     }
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -206,7 +206,7 @@
 
 		<!-- Settings Panel (hidden for basic users) -->
 		{#if !isBasicUser}
-			<SettingsPanel />
+			<SettingsPanel isAdmin={data.user?.role === 'admin'} />
 		{/if}
 
 		<!-- ESP32 Sensor Configuration (admin only) -->


### PR DESCRIPTION
## Summary

- Backend: `TargetTemperatureService::stop()` now also deletes orphaned `heat-target-*.json` job files
- Frontend: Added admin-only "Server Heat-Target Status" section with cancel button

This addresses the cascading heat-target cron jobs issue where jobs were firing 5 hours late due to timezone bug, creating new jobs in an infinite loop.

**Note:** This is a cleanup tool, not a fix for the root cause. The timezone DRY refactor is on `feature/cron-dry-refactor`.

## Test plan

- [x] Backend unit tests (RED-GREEN verified)
- [x] Frontend component tests (10 new tests)
- [x] Full test suite passes (632 backend, 166 frontend)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)