### PR TITLE
Fix heat-to-target stop() to turn off heater when canceling

### DIFF
--- a/backend/src/Services/TargetTemperatureService.php
+++ b/backend/src/Services/TargetTemperatureService.php
@@ -78,6 +78,13 @@ class TargetTemperatureService
 
     public function stop(): void
     {
+        // Turn off heater if it's currently on
+        $equipmentState = $this->equipmentStatus?->getStatus() ?? ['heater' => ['on' => false]];
+        if ($equipmentState['heater']['on'] === true) {
+            $this->iftttClient?->trigger('hot-tub-heat-off');
+            $this->equipmentStatus?->setHeaterOff();
+        }
+
         // Delete the state file
         if (file_exists($this->stateFile)) {
             unlink($this->stateFile);

--- a/backend/tests/Services/TargetTemperatureServiceTest.php
+++ b/backend/tests/Services/TargetTemperatureServiceTest.php
@@ -141,6 +141,38 @@ class TargetTemperatureServiceTest extends TestCase
         $this->assertFalse($state['active']);
     }
 
+    public function testStopTurnsOffHeaterWhenHeaterIsOn(): void
+    {
+        $this->equipmentStatus->setHeaterOn();
+
+        $this->mockIfttt->expects($this->once())
+            ->method('trigger')
+            ->with('hot-tub-heat-off')
+            ->willReturn(true);
+
+        $service = $this->createService();
+        $service->start(103.5);
+
+        $service->stop();
+
+        $this->assertFalse($this->equipmentStatus->getStatus()['heater']['on']);
+    }
+
+    public function testStopDoesNotTriggerIftttWhenHeaterAlreadyOff(): void
+    {
+        $this->equipmentStatus->setHeaterOff();
+
+        $this->mockIfttt->expects($this->never())
+            ->method('trigger');
+
+        $service = $this->createService();
+        $service->start(103.5);
+
+        $service->stop();
+
+        $this->assertFalse($this->equipmentStatus->getStatus()['heater']['on']);
+    }
+
     // ========== Job file cleanup tests ==========
 
     public function testStopCleansUpHeatTargetJobFiles(): void


### PR DESCRIPTION
## Summary
- Fix bug where canceling heat-to-target left equipment-status.json showing heater=ON
- The `stop()` method now turns off the heater (via IFTTT) if it's currently on
- Prevents stale state that caused ESP32 to receive 60-second intervals indefinitely

## Test plan
- [x] Unit tests added: `testStopTurnsOffHeaterWhenHeaterIsOn`, `testStopDoesNotTriggerIftttWhenHeaterAlreadyOff`
- [x] All 651 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)