### PR TITLE
Fix heaterOff to cancel heat-to-target, add admin crontab endpoint

### DIFF
--- a/backend/tests/Integration/TargetTemperatureIntegrationTest.php
+++ b/backend/tests/Integration/TargetTemperatureIntegrationTest.php
@@ -103,7 +103,8 @@ class TargetTemperatureIntegrationTest extends TestCase
             ->method('addEntry')
             ->with($this->stringContains('HOTTUB:heat-target'));
 
-        $this->mockCrontab->expects($this->once())
+        // Called twice: once for cleanup, once for race condition protection
+        $this->mockCrontab->expects($this->exactly(2))
             ->method('removeByPattern')
             ->with('HOTTUB:heat-target');
 
@@ -161,7 +162,8 @@ class TargetTemperatureIntegrationTest extends TestCase
 
         $this->mockIfttt->method('trigger')->willReturn(true);
         $this->mockCrontab->method('addEntry');
-        $this->mockCrontab->expects($this->once())
+        // Called twice: once for cleanup, once for race condition protection
+        $this->mockCrontab->expects($this->exactly(2))
             ->method('removeByPattern')
             ->with('HOTTUB:heat-target');
 


### PR DESCRIPTION
## Summary
- HeaterOff now cancels active heat-to-target (manual user action overrides automation)
- Fixed `calculateNextCheckTime` to not sync with ESP32 timing (was causing skipped minutes like 06:57 → 06:59)
- Added race condition protection in `stop()` (double cleanup with 100ms delay)
- Added `GET /api/admin/crontab` endpoint for debugging cron state without SSH
- `stop()` now properly calls `cleanupCronJobs()` (was missing, causing orphaned cron jobs)

## Test plan
- [x] All 657 tests pass
- [ ] Deploy and verify heaterOff cancels heat-to-target
- [ ] Verify admin crontab endpoint works

🤖 Generated with [Claude Code](https://claude.com/claude-code)