### PR TITLE
Fix log rotation cron blocked by ModSecurity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -308,6 +308,8 @@ FTP credentials in `backend/config/env.production` provide access to the product
 - NEVER use FTP, curl, or any other method to upload/modify files on production
 - Even for urgent hotfixes, use the PR workflow (it only takes a minute)
 
+**LiteSpeed/ModSecurity quirk:** The shared hosting blocks empty POST requests with 403 Forbidden. Any curl POST must include a body (use `-d '{}'` for endpoints that don't require parameters).
+
 ## Development Methodology: TDD Red/Green
 
 **All new functionality MUST follow Test-Driven Development:**

--- a/backend/storage/bin/log-rotation-cron.sh
+++ b/backend/storage/bin/log-rotation-cron.sh
@@ -60,10 +60,12 @@ FULL_URL="${API_BASE_URL}/api/maintenance/logs/rotate"
 log "Calling API: POST $FULL_URL"
 
 HTTP_RESPONSE=$(mktemp)
+# Note: -d '{}' is required - LiteSpeed/ModSecurity blocks empty POST requests
 HTTP_CODE=$(curl -s -w "%{http_code}" -o "$HTTP_RESPONSE" \
     -X POST "$FULL_URL" \
     -H "Authorization: Bearer $CRON_JWT" \
     -H "Content-Type: application/json" \
+    -d '{}' \
     --max-time 60 \
     2>&1) || HTTP_CODE="000"
 


### PR DESCRIPTION
## Summary
- Fix monthly log rotation cron job that was being blocked by LiteSpeed/ModSecurity
- Empty POST requests return 403 Forbidden on shared hosting
- Added `-d '{}'` to curl command to include empty JSON body

## Test plan
- [x] Manually triggered log rotation endpoint with fix - returned 200
- [x] Verified healthchecks.io received ping (status changed from "down" to "up")
- [x] Backend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)