### PR TITLE
Prevent duplicate heat-to-target sessions

### DIFF
--- a/backend/src/Controllers/TargetTemperatureController.php
+++ b/backend/src/Controllers/TargetTemperatureController.php
@@ -37,6 +37,11 @@ class TargetTemperatureController
                 'status' => 400,
                 'body' => ['error' => $e->getMessage()],
             ];
+        } catch (\RuntimeException $e) {
+            return [
+                'status' => 409,
+                'body' => ['error' => $e->getMessage()],
+            ];
         }
 
         // Return the checkAndAdjust result which includes heater state, cron scheduled, etc.


### PR DESCRIPTION
## Summary
- Add `flock`-based locking to `TargetTemperatureService` to prevent concurrent heating sessions
- `start()` checks state under lock and throws `RuntimeException` if already active (controller returns 409 Conflict)
- `checkAndAdjust()` serializes concurrent cron checks via the same lock, gracefully skipping on contention

Fixes #113

## Test plan
- [x] 5 new service tests + 1 controller test for duplicate prevention
- [x] All 732 backend tests pass
- [x] Full suite (backend + frontend + ESP32 + E2E) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)