### PR TITLE
Smart approach scheduling for heat-to-target

### DIFF
--- a/backend/src/Services/TargetTemperatureService.php
+++ b/backend/src/Services/TargetTemperatureService.php
@@ -311,8 +311,9 @@ class TargetTemperatureService
                 $heaterTurnedOn = true;
             }
 
-            // Schedule next check
-            $cronScheduled = $this->scheduleNextCheck();
+            // Schedule next check — use smart approach scheduling on first check
+            $cronScheduled = $this->scheduleApproachCheckIfEligible($state, $currentTempF, $targetTempF)
+                ?: $this->scheduleNextCheck();
 
             return [
                 'active' => true,
@@ -496,6 +497,7 @@ class TargetTemperatureService
     }
 
     private const CRON_SAFETY_MARGIN_SECONDS = 5;
+    private const MIN_SMART_SCHEDULING_MINUTES = 3;
 
     /**
      * Calculate when the next check should occur.
@@ -531,19 +533,97 @@ class TargetTemperatureService
     }
 
     /**
-     * Schedule the next temperature check via cron.
+     * On the first check of a session, schedule a single approach check near
+     * the predicted target arrival time instead of starting 1-minute checks
+     * immediately. This reduces cron count from ~30 to ~10 per session.
+     *
+     * Returns true if an approach check was scheduled, false to fall through
+     * to legacy 1-minute scheduling.
+     */
+    private function scheduleApproachCheckIfEligible(array &$state, float $currentTempF, float $targetTempF): bool
+    {
+        // Only on the first check (approach not yet scheduled)
+        if (isset($state['approach_check_at'])) {
+            return false;
+        }
+
+        // Need heating characteristics for prediction
+        if ($this->heatingCharacteristicsFile === null || !file_exists($this->heatingCharacteristicsFile)) {
+            return false;
+        }
+        $chars = json_decode(file_get_contents($this->heatingCharacteristicsFile), true);
+        if (!is_array($chars) || empty($chars['heating_velocity_f_per_min'])) {
+            return false;
+        }
+
+        $velocity = (float) $chars['heating_velocity_f_per_min'];
+        if ($velocity <= 0) {
+            return false;
+        }
+
+        // Calculate approach time WITHOUT startup lag — this is the earliest
+        // the tub could reach target (if hot water is already in pipes)
+        $approachMinutes = ($targetTempF - $currentTempF) / $velocity;
+
+        if ($approachMinutes < self::MIN_SMART_SCHEDULING_MINUTES) {
+            return false;
+        }
+
+        $approachTimestamp = $this->roundToMinuteBoundary(
+            time() + (int) ($approachMinutes * 60)
+        );
+
+        $scheduled = $this->scheduleCheckAt($approachTimestamp);
+        if (!$scheduled) {
+            return false;
+        }
+
+        // Record in state so subsequent checks use 1-minute scheduling
+        $state['approach_check_at'] = (new \DateTimeImmutable(
+            '@' . $approachTimestamp
+        ))->format('c');
+        $this->saveState($state);
+
+        return true;
+    }
+
+    /**
+     * Round a Unix timestamp up to the next minute boundary with safety margin.
+     */
+    private function roundToMinuteBoundary(int $timestamp): int
+    {
+        $boundary = (int) ceil($timestamp / 60) * 60;
+
+        if (($boundary - time()) < self::CRON_SAFETY_MARGIN_SECONDS) {
+            $boundary += 60;
+        }
+
+        return $boundary;
+    }
+
+    /**
+     * Schedule the next temperature check at the next available minute.
+     */
+    private function scheduleNextCheck(): bool
+    {
+        return $this->scheduleCheckAt($this->calculateNextCheckTime());
+    }
+
+    /**
+     * Schedule a temperature check at a specific time.
      *
      * Uses CronSchedulingService to ensure correct timezone handling.
      * Creates a job file and crontab entry that uses cron-runner.sh for
      * proper JWT authentication.
+     *
+     * @param int $timestamp Unix timestamp for when the check should fire
      */
-    private function scheduleNextCheck(): bool
+    private function scheduleCheckAt(int $timestamp): bool
     {
         if ($this->cronSchedulingService === null || $this->cronRunnerPath === null || $this->apiBaseUrl === null) {
             return false;
         }
 
-        $checkTime = $this->calculateNextCheckTime();
         $jobId = self::CRON_JOB_PREFIX . '-' . bin2hex(random_bytes(4));
 
         // Create job file for cron-runner.sh to read
@@ -559,7 +639,7 @@ class TargetTemperatureService
 
         // Use CronSchedulingService for correct timezone handling
         // This ensures cron fires at the right time regardless of PHP timezone
-        $this->cronSchedulingService->scheduleAt($checkTime, $command, $comment);
+        $this->cronSchedulingService->scheduleAt($timestamp, $command, $comment);
 
         return true;
     }

--- a/backend/tests/Services/TargetTemperatureServiceTest.php
+++ b/backend/tests/Services/TargetTemperatureServiceTest.php
@@ -10,6 +10,7 @@ use HotTub\Services\EquipmentStatusService;
 use HotTub\Services\Esp32TemperatureService;
 use HotTub\Services\Esp32SensorConfigService;
 use HotTub\Services\HeatTargetSettingsService;
+use HotTub\Services\CronSchedulingService;
 use HotTub\Services\TargetTemperatureService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -1347,5 +1348,155 @@ class TargetTemperatureServiceTest extends TestCase
         $this->assertNotNull($eta);
         // Falls back to static target (102.0 from createDynamicHeatTargetSettings)
         $this->assertEqualsWithDelta(102.0, $eta['target_temp_f'], 0.1);
+    }
+
+    // ========================================================================
+    // Smart Approach Scheduling Tests
+    // ========================================================================
+
+    /**
+     * Helper: create a service with a mock CronSchedulingService to capture
+     * the Unix timestamps passed to scheduleAt().
+     *
+     * @param array<int, int> &$capturedTimestamps Receives timestamps from scheduleAt() calls
+     */
+    private function createServiceWithSmartScheduling(
+        ?string $heatingCharsFile,
+        array &$capturedTimestamps
+    ): TargetTemperatureService {
+        $mockCronScheduling = $this->createMock(CronSchedulingService::class);
+        $mockCronScheduling->method('scheduleAt')
+            ->willReturnCallback(function (int $timestamp, string $command, string $comment) use (&$capturedTimestamps) {
+                $capturedTimestamps[] = $timestamp;
+                return '0 0 * * *'; // dummy cron expression
+            });
+
+        return new TargetTemperatureService(
+            $this->stateFile,
+            $this->mockIfttt,
+            $this->equipmentStatus,
+            $this->esp32Temp,
+            $this->mockCrontab,
+            '/path/to/cron-runner.sh',
+            'https://example.com/api',
+            $this->esp32Config,
+            $mockCronScheduling,
+            null, // heatTargetSettings
+            null, // stallEventFile
+            null, // equipmentEventLogFile
+            $heatingCharsFile
+        );
+    }
+
+    public function testStartSchedulesApproachCheckWhenCharacteristicsAvailable(): void
+    {
+        // velocity=0.4 F/min, lag=5 min. Current=90, target=102.
+        // Approach time = (102-90)/0.4 = 30 min from now (no lag).
+        $charsFile = $this->createHeatingCharacteristicsFile(0.4, 5.0);
+        $capturedTimestamps = [];
+        $service = $this->createServiceWithSmartScheduling($charsFile, $capturedTimestamps);
+        $this->storeEsp32Reading(90.0);
+
+        $service->start(102.0);
+
+        // Should have exactly 1 cron entry (the approach check)
+        $this->assertCount(1, $capturedTimestamps, 'Expected exactly 1 cron entry (approach check)');
+
+        // The cron should be scheduled ~30 min from now, not ~1 min
+        $diffMinutes = ($capturedTimestamps[0] - time()) / 60;
+        $this->assertGreaterThanOrEqual(25, $diffMinutes, 'Approach check should be ~30 min out, not 1 min');
+        $this->assertLessThanOrEqual(35, $diffMinutes, 'Approach check should be ~30 min out');
+
+        // State should have approach_check_at
+        $state = $service->getState();
+        $this->assertArrayHasKey('approach_check_at', $state);
+    }
+
+    public function testApproachCheckExcludesStartupLag(): void
+    {
+        // velocity=0.4 F/min, lag=5 min. Current=90, target=102.
+        // Without lag: 30 min. With lag: 35 min.
+        // Approach should be ~30 min, not ~35.
+        $charsFile = $this->createHeatingCharacteristicsFile(0.4, 5.0);
+        $capturedTimestamps = [];
+        $service = $this->createServiceWithSmartScheduling($charsFile, $capturedTimestamps);
+        $this->storeEsp32Reading(90.0);
+
+        $service->start(102.0);
+
+        $this->assertNotEmpty($capturedTimestamps);
+
+        $diffMinutes = ($capturedTimestamps[0] - time()) / 60;
+        // Must be closer to 30 than to 35 (lag should NOT be included)
+        $this->assertLessThanOrEqual(33, $diffMinutes, 'Approach check should exclude startup lag');
+    }
+
+    public function testFallsBackToLegacyWhenNoCharacteristics(): void
+    {
+        // No characteristics file → should schedule at next minute (legacy)
+        $capturedTimestamps = [];
+        $service = $this->createServiceWithSmartScheduling(null, $capturedTimestamps);
+        $this->storeEsp32Reading(90.0);
+
+        $service->start(102.0);
+
+        $this->assertNotEmpty($capturedTimestamps);
+
+        // Legacy: should be 1-2 minutes from now
+        $diffMinutes = ($capturedTimestamps[0] - time()) / 60;
+        $this->assertLessThanOrEqual(3, $diffMinutes, 'Without characteristics, should use 1-min scheduling');
+
+        // State should NOT have approach_check_at
+        $state = $service->getState();
+        $this->assertArrayNotHasKey('approach_check_at', $state);
+    }
+
+    public function testFallsBackToLegacyWhenTempDeltaSmall(): void
+    {
+        // velocity=0.4, current=101.5, target=102 → (0.5/0.4)=1.25 min < 3 min threshold
+        $charsFile = $this->createHeatingCharacteristicsFile(0.4, 5.0);
+        $capturedTimestamps = [];
+        $service = $this->createServiceWithSmartScheduling($charsFile, $capturedTimestamps);
+        $this->storeEsp32Reading(101.5);
+
+        $service->start(102.0);
+
+        $this->assertNotEmpty($capturedTimestamps);
+
+        // Should be 1-2 min (legacy), not using smart scheduling
+        $diffMinutes = ($capturedTimestamps[0] - time()) / 60;
+        $this->assertLessThanOrEqual(3, $diffMinutes, 'Small delta should use 1-min scheduling');
+
+        $state = $service->getState();
+        $this->assertArrayNotHasKey('approach_check_at', $state);
+    }
+
+    public function testSubsequentChecksUseMinuteScheduling(): void
+    {
+        // Simulate: approach already fired (approach_check_at is set in state).
+        // Next checkAndAdjust should schedule at next minute, not another approach.
+        $charsFile = $this->createHeatingCharacteristicsFile(0.4, 5.0);
+        $capturedTimestamps = [];
+        $service = $this->createServiceWithSmartScheduling($charsFile, $capturedTimestamps);
+
+        // Manually write state with approach_check_at already set
+        file_put_contents($this->stateFile, json_encode([
+            'active' => true,
+            'target_temp_f' => 102.0,
+            'started_at' => (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('c'),
+            'approach_check_at' => (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('c'),
+        ]));
+
+        $this->storeEsp32Reading(99.0); // below target, still heating
+        $this->equipmentStatus->setHeaterOn();
+
+        $result = $service->checkAndAdjust();
+
+        $this->assertTrue($result['heating']);
+        $this->assertNotEmpty($capturedTimestamps);
+
+        // Should be 1-2 min from now (minute chain), not a far-future approach
+        $diffMinutes = ($capturedTimestamps[0] - time()) / 60;
+        $this->assertLessThanOrEqual(3, $diffMinutes, 'After approach fired, should use 1-min scheduling');
     }
 }

--- a/frontend/e2e/heat-target-settings.spec.ts
+++ b/frontend/e2e/heat-target-settings.spec.ts
@@ -151,8 +151,7 @@ test.describe('Heat Target Settings (Admin Only)', () => {
 
 			// Verify UI reflects the settings
 			const checkbox = page.getByLabel('Enable heat to target');
-			await expect(checkbox).toBeVisible({ timeout: 10000 });
-			expect(await checkbox.isChecked()).toBe(true);
+			await expect(checkbox).toBeChecked({ timeout: 10000 });
 
 			const input = page.getByLabel('Target temp input');
 			await expect(input).toHaveValue('105');
@@ -210,8 +209,7 @@ test.describe('Heat Target Settings (Admin Only)', () => {
 
 			// Verify settings persisted
 			const checkboxAfter = page.getByLabel('Enable heat to target');
-			await expect(checkboxAfter).toBeVisible({ timeout: 10000 });
-			expect(await checkboxAfter.isChecked()).toBe(true);
+			await expect(checkboxAfter).toBeChecked({ timeout: 10000 });
 
 			const inputAfter = page.getByLabel('Target temp input');
 			await expect(inputAfter).toHaveValue('107');

--- a/frontend/e2e/scheduler-recurring.spec.ts
+++ b/frontend/e2e/scheduler-recurring.spec.ts
@@ -89,6 +89,7 @@ test.describe.serial('Scheduler Recurring Jobs', () => {
 
 		// Create a recurring job with a unique time
 		await page.locator('label:has-text("Recurring (daily)")').click({ force: true });
+		await expect(page.getByRole('checkbox', { name: 'Recurring (daily)' })).toBeChecked({ timeout: 5000 });
 		await page.selectOption('#action', 'heater-on');
 		await page.fill('#time', '08:30');
 		await page.click('button:has-text("Schedule")', { force: true });
@@ -130,11 +131,9 @@ test.describe.serial('Scheduler Recurring Jobs', () => {
 		await page.fill('#time', '05:30');
 		await page.click('button:has-text("Schedule")', { force: true });
 
-		// Verify success message mentions auto off
-		await expect(page.locator('text=auto off')).toBeVisible({ timeout: 10000 });
-
 		// Verify two NEW jobs appear in Daily Schedule (heater-on and heater-off)
-		await expect(dailyJobsLocator).toHaveCount(initialCount + 2, { timeout: 5000 });
+		// This implicitly waits for both API calls to complete and jobs to render
+		await expect(dailyJobsLocator).toHaveCount(initialCount + 2, { timeout: 15000 });
 
 		// Verify new jobs are Heater ON at 5:30 and Heater OFF at 8:00 (150 min later)
 		await expect(page.locator('li').filter({ hasText: 'Heater ON' }).filter({ hasText: '5:30' }).first()).toBeVisible();
@@ -177,6 +176,7 @@ test.describe.serial('Scheduler Recurring Jobs', () => {
 	test('both recurring and one-off jobs can coexist', async ({ page }) => {
 		// Create a recurring job first (unique time)
 		await page.locator('label:has-text("Recurring (daily)")').click({ force: true });
+		await expect(page.getByRole('checkbox', { name: 'Recurring (daily)' })).toBeChecked({ timeout: 5000 });
 		await page.selectOption('#action', 'heater-on');
 		await page.fill('#time', '04:00');
 		await page.click('button:has-text("Schedule")', { force: true });

--- a/frontend/e2e/scheduler-skip.spec.ts
+++ b/frontend/e2e/scheduler-skip.spec.ts
@@ -38,6 +38,7 @@ test.describe.serial('Scheduler Skip Next Occurrence', () => {
 	test('recurring job shows "Skip next" button', async ({ page }) => {
 		// Create a recurring job
 		await page.locator('label:has-text("Recurring (daily)")').click({ force: true });
+		await expect(page.getByRole('checkbox', { name: 'Recurring (daily)' })).toBeChecked({ timeout: 5000 });
 		await page.selectOption('#action', 'heater-on');
 		await page.fill('#time', '07:00');
 		await page.click('button:has-text("Schedule")', { force: true });
@@ -52,6 +53,7 @@ test.describe.serial('Scheduler Skip Next Occurrence', () => {
 	test('clicking "Skip next" changes to amber/skipped state with Unskip button', async ({ page }) => {
 		// Create a recurring job
 		await page.locator('label:has-text("Recurring (daily)")').click({ force: true });
+		await expect(page.getByRole('checkbox', { name: 'Recurring (daily)' })).toBeChecked({ timeout: 5000 });
 		await page.selectOption('#action', 'heater-on');
 		await page.fill('#time', '07:15');
 		await page.click('button:has-text("Schedule")', { force: true });
@@ -79,6 +81,7 @@ test.describe.serial('Scheduler Skip Next Occurrence', () => {
 	test('clicking "Unskip" restores normal purple state', async ({ page }) => {
 		// Create and skip a recurring job
 		await page.locator('label:has-text("Recurring (daily)")').click({ force: true });
+		await expect(page.getByRole('checkbox', { name: 'Recurring (daily)' })).toBeChecked({ timeout: 5000 });
 		await page.selectOption('#action', 'heater-on');
 		await page.fill('#time', '07:30');
 		await page.click('button:has-text("Schedule")', { force: true });
@@ -106,6 +109,7 @@ test.describe.serial('Scheduler Skip Next Occurrence', () => {
 	test('cancel works on skipped jobs', async ({ page }) => {
 		// Create and skip a recurring job
 		await page.locator('label:has-text("Recurring (daily)")').click({ force: true });
+		await expect(page.getByRole('checkbox', { name: 'Recurring (daily)' })).toBeChecked({ timeout: 5000 });
 		await page.selectOption('#action', 'heater-on');
 		await page.fill('#time', '07:45');
 		await page.click('button:has-text("Schedule")', { force: true });


### PR DESCRIPTION
## Summary
- Uses heating characteristics (velocity) to predict when the tub will approach target temperature, scheduling the first check near that time instead of immediately starting 1-minute cron checks
- Reduces cron count from ~30 to ~10 per heating session, mitigating the CloudLinux CageFS process-killing that broke the check chain on 2026-04-08
- Falls back to legacy 1-minute scheduling when no characteristics are available
- Fixes 4 flaky E2E tests (non-retrying assertions, ephemeral message races, unverified checkbox toggles)

## Test plan
- [x] 913 backend unit tests pass (5 new smart scheduling tests)
- [x] 198 frontend unit tests pass
- [x] 123 E2E tests pass (0 failures, up from 122 previously)
- [ ] Monitor tomorrow's heating cycle in production to verify smart scheduling fires correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)