### PR TITLE
Unified heater control + watchdog safety cron

### DIFF
--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -26,6 +26,7 @@ use HotTub\Services\ScheduledJobsCleanupService;
 use HotTub\Services\EnvLoader;
 use HotTub\Services\CookieHelper;
 use HotTub\Services\EquipmentStatusService;
+use HotTub\Services\HeaterControlService;
 use HotTub\Services\IftttClientFactory;
 use HotTub\Services\AuthService;
 use HotTub\Services\UserRepositoryFactory;
@@ -148,13 +149,18 @@ $crontabAdapter = new CrontabAdapter($crontabBackupService);
 // Path for stall event file (used by health endpoint and target temperature service)
 $stallEventFile = __DIR__ . '/../storage/state/last-stall-event.json';
 
+// Unified hardware control: single point for all IFTTT triggers
+// Includes crontab access for watchdog cron cleanup on heater-on events
+$scheduledJobsDir = __DIR__ . '/../storage/scheduled-jobs';
+$heaterControlService = new HeaterControlService($iftttClient, $equipmentStatusService, $crontabAdapter, $scheduledJobsDir);
+
 // Create target temperature service and controller
 // (for automated heating to target temperature)
 $targetTempStateFile = __DIR__ . '/../storage/state/target-temperature.json';
 $heatingCharacteristicsResultsFile = __DIR__ . '/../storage/state/heating-characteristics.json';
 $targetTemperatureService = new TargetTemperatureService(
     $targetTempStateFile,
-    $iftttClient,
+    $heaterControlService,
     $equipmentStatusService,
     $esp32TemperatureService,
     $crontabAdapter,
@@ -172,7 +178,7 @@ $targetTemperatureController = new TargetTemperatureController($targetTemperatur
 // Create equipment controller with IFTTT client, status service, and target temp service
 // Note: TargetTemperatureService is passed so heaterOff() can cancel heat-to-target
 // (manual user action should override automation)
-$equipmentController = new EquipmentController($logFile, $iftttClient, $equipmentStatusService, $targetTemperatureService);
+$equipmentController = new EquipmentController($logFile, $heaterControlService, $equipmentStatusService, $targetTemperatureService);
 
 // Create Healthchecks.io client for job monitoring (feature flag: disabled if no API key)
 $healthchecksFactory = new HealthchecksClientFactory($config);
@@ -272,7 +278,7 @@ $router->get('/api/auth/me', fn() => handleMe($authController, $headers, $cookie
 
 // Protected equipment routes (with auth middleware)
 $router->post('/api/equipment/heater/on', fn() => $equipmentController->heaterOn(), $requireAuth);
-$router->post('/api/equipment/heater/off', fn() => $equipmentController->heaterOff(), $requireAuth);
+$router->post('/api/equipment/heater/off', fn() => $equipmentController->heaterOff($_GET['source'] ?? null), $requireAuth);
 $router->post('/api/equipment/pump/run', fn() => $equipmentController->pumpRun(), $requireAuth);
 
 // Target temperature routes (heat to specific temperature)

--- a/backend/src/Controllers/EquipmentController.php
+++ b/backend/src/Controllers/EquipmentController.php
@@ -6,14 +6,16 @@ namespace HotTub\Controllers;
 
 use HotTub\Services\EventLogger;
 use HotTub\Services\EquipmentStatusService;
+use HotTub\Services\HeaterControlService;
 use HotTub\Services\TargetTemperatureService;
-use HotTub\Contracts\IftttClientInterface;
 
 /**
  * Controller for hot tub equipment operations.
  *
- * All equipment control operations trigger IFTTT webhooks,
- * log events for audit purposes, and update equipment status.
+ * All equipment control operations go through HeaterControlService for
+ * consistent IFTTT triggering, success checking, and status updates.
+ * This controller adds API response formatting, request-level logging,
+ * and heat-to-target cancellation on manual heater-off.
  */
 class EquipmentController
 {
@@ -21,7 +23,7 @@ class EquipmentController
 
     public function __construct(
         string $logFile,
-        private IftttClientInterface $iftttClient,
+        private HeaterControlService $heaterControl,
         private ?EquipmentStatusService $statusService = null,
         private ?TargetTemperatureService $targetTempService = null
     ) {
@@ -37,7 +39,7 @@ class EquipmentController
     {
         $body = [
             'status' => 'ok',
-            'ifttt_mode' => $this->iftttClient->getMode(),
+            'ifttt_mode' => $this->heaterControl->getMode(),
         ];
 
         if ($this->statusService !== null) {
@@ -61,15 +63,11 @@ class EquipmentController
     public function heaterOn(): array
     {
         $timestamp = date('c');
-        $success = $this->iftttClient->trigger('hot-tub-heat-on');
-
-        if ($success && $this->statusService !== null) {
-            $this->statusService->setHeaterOn();
-        }
+        $success = $this->heaterControl->heaterOn();
 
         $this->logger->log('heater_on', [
             'ifttt_success' => $success,
-            'ifttt_mode' => $this->iftttClient->getMode(),
+            'ifttt_mode' => $this->heaterControl->getMode(),
         ]);
 
         return [
@@ -97,15 +95,20 @@ class EquipmentController
      * confusing UX where the heater turns back on 60 seconds later.
      * Manual user action should override automation.
      */
-    public function heaterOff(): array
+    public function heaterOff(?string $source = null): array
     {
         $timestamp = date('c');
-        $success = $this->iftttClient->trigger('hot-tub-heat-off');
 
-        if ($success && $this->statusService !== null) {
-            $this->statusService->setHeaterOff();
-            $this->statusService->setPumpOff();
+        // Watchdog: check equipment state before issuing heater-off
+        // so we can log whether the heater was unexpectedly still on.
+        if ($source === 'watchdog') {
+            $heaterWasOn = $this->statusService?->getStatus()['heater']['on'] ?? false;
+            $this->logger->log('watchdog_heater_off', [
+                'heater_was_on' => $heaterWasOn,
+            ]);
         }
+
+        $success = $this->heaterControl->heaterOff();
 
         // Cancel heat-to-target if active (manual action overrides automation)
         $heatToTargetCanceled = false;
@@ -119,18 +122,24 @@ class EquipmentController
 
         $this->logger->log('heater_off', [
             'ifttt_success' => $success,
-            'ifttt_mode' => $this->iftttClient->getMode(),
+            'ifttt_mode' => $this->heaterControl->getMode(),
             'heat_to_target_canceled' => $heatToTargetCanceled,
         ]);
 
+        $body = [
+            'success' => $success,
+            'action' => 'heater_off',
+            'timestamp' => $timestamp,
+            'heat_to_target_canceled' => $heatToTargetCanceled,
+        ];
+
+        if ($source !== null) {
+            $body['source'] = $source;
+        }
+
         return [
             'status' => $success ? 200 : 500,
-            'body' => [
-                'success' => $success,
-                'action' => 'heater_off',
-                'timestamp' => $timestamp,
-                'heat_to_target_canceled' => $heatToTargetCanceled,
-            ],
+            'body' => $body,
         ];
     }
 
@@ -144,16 +153,12 @@ class EquipmentController
     {
         $timestamp = date('c');
         $duration = 7200; // 2 hours in seconds
-        $success = $this->iftttClient->trigger('cycle_hot_tub_ionizer');
-
-        if ($success && $this->statusService !== null) {
-            $this->statusService->setPumpOn();
-        }
+        $success = $this->heaterControl->pumpRun();
 
         $this->logger->log('pump_run', [
             'duration' => $duration,
             'ifttt_success' => $success,
-            'ifttt_mode' => $this->iftttClient->getMode(),
+            'ifttt_mode' => $this->heaterControl->getMode(),
         ]);
 
         return [

--- a/backend/src/Services/HeaterControlService.php
+++ b/backend/src/Services/HeaterControlService.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Services;
+
+use HotTub\Contracts\CrontabAdapterInterface;
+use HotTub\Contracts\IftttClientInterface;
+
+/**
+ * Unified hardware control: single point for all IFTTT triggers.
+ *
+ * Every heater/pump on/off action goes through this service, ensuring
+ * consistent IFTTT triggering, success checking, and equipment status updates.
+ * Also handles watchdog cron cleanup on heater-on events.
+ */
+class HeaterControlService
+{
+    public function __construct(
+        private IftttClientInterface $iftttClient,
+        private EquipmentStatusService $statusService,
+        private ?CrontabAdapterInterface $crontabAdapter = null,
+        private ?string $jobsDir = null,
+    ) {}
+
+    public function heaterOn(): bool
+    {
+        // Clear any existing watchdog crons — a new heater-on event means
+        // either a new session (which will schedule its own watchdog) or a
+        // manual action (which shouldn't be fought by a stale watchdog).
+        $this->cleanupWatchdogCrons();
+
+        $success = $this->iftttClient->trigger('hot-tub-heat-on');
+        if ($success) {
+            $this->statusService->setHeaterOn();
+        }
+        return $success;
+    }
+
+    private function cleanupWatchdogCrons(): void
+    {
+        if ($this->crontabAdapter !== null) {
+            TargetTemperatureService::cleanupWatchdogCrons($this->crontabAdapter, $this->jobsDir);
+        }
+    }
+
+    public function heaterOff(): bool
+    {
+        $success = $this->iftttClient->trigger('hot-tub-heat-off');
+        if ($success) {
+            $this->statusService->setHeaterOff();
+            $this->statusService->setPumpOff();
+        }
+        return $success;
+    }
+
+    public function pumpRun(): bool
+    {
+        $success = $this->iftttClient->trigger('cycle_hot_tub_ionizer');
+        if ($success) {
+            $this->statusService->setPumpOn();
+        }
+        return $success;
+    }
+
+    public function getMode(): string
+    {
+        return $this->iftttClient->getMode();
+    }
+}

--- a/backend/src/Services/TargetTemperatureService.php
+++ b/backend/src/Services/TargetTemperatureService.php
@@ -5,19 +5,20 @@ declare(strict_types=1);
 namespace HotTub\Services;
 
 use HotTub\Contracts\CrontabAdapterInterface;
-use HotTub\Contracts\IftttClientInterface;
 
 class TargetTemperatureService
 {
     public const MIN_TARGET_TEMP_F = 80.0;
     public const MAX_TARGET_TEMP_F = 110.0;
     public const CRON_JOB_PREFIX = 'heat-target';
+    public const WATCHDOG_JOB_PREFIX = 'watchdog';
+    public const WATCHDOG_MARGIN_MINUTES = 10;
     // Temperature tolerance for floating-point comparison (0.1°F)
     // This accounts for C→F conversion precision and sensor accuracy
     private const TEMP_TOLERANCE_F = 0.1;
 
     private string $stateFile;
-    private ?IftttClientInterface $iftttClient;
+    private ?HeaterControlService $heaterControl;
     private ?EquipmentStatusService $equipmentStatus;
     private ?Esp32TemperatureService $esp32Temp;
     private ?CrontabAdapterInterface $crontabAdapter;
@@ -32,7 +33,7 @@ class TargetTemperatureService
 
     public function __construct(
         string $stateFile,
-        ?IftttClientInterface $iftttClient = null,
+        ?HeaterControlService $heaterControl = null,
         ?EquipmentStatusService $equipmentStatus = null,
         ?Esp32TemperatureService $esp32Temp = null,
         ?CrontabAdapterInterface $crontabAdapter = null,
@@ -46,7 +47,7 @@ class TargetTemperatureService
         ?string $heatingCharacteristicsFile = null
     ) {
         $this->stateFile = $stateFile;
-        $this->iftttClient = $iftttClient;
+        $this->heaterControl = $heaterControl;
         $this->equipmentStatus = $equipmentStatus;
         $this->esp32Temp = $esp32Temp;
         $this->crontabAdapter = $crontabAdapter;
@@ -161,8 +162,7 @@ class TargetTemperatureService
         // Turn off heater if it's currently on
         $equipmentState = $this->equipmentStatus?->getStatus() ?? ['heater' => ['on' => false]];
         if ($equipmentState['heater']['on'] === true) {
-            $this->iftttClient?->trigger('hot-tub-heat-off');
-            $this->equipmentStatus?->setHeaterOff();
+            $this->heaterControl?->heaterOff();
         }
 
         // Delete the state file FIRST - this prevents any concurrent cron job
@@ -306,8 +306,7 @@ class TargetTemperatureService
 
             if (!$heaterIsOn) {
                 // Turn heater on
-                $this->iftttClient?->trigger('hot-tub-heat-on');
-                $this->equipmentStatus?->setHeaterOn();
+                $this->heaterControl?->heaterOn();
                 $heaterTurnedOn = true;
             }
 
@@ -331,8 +330,7 @@ class TargetTemperatureService
 
         if ($heaterIsOn) {
             // Turn heater off
-            $this->iftttClient?->trigger('hot-tub-heat-off');
-            $this->equipmentStatus?->setHeaterOff();
+            $this->heaterControl?->heaterOff();
             $heaterTurnedOff = true;
         }
 
@@ -578,6 +576,14 @@ class TargetTemperatureService
             return false;
         }
 
+        // Schedule watchdog: approach + startup lag + margin
+        $startupLag = (float) ($chars['startup_lag_minutes'] ?? 0);
+        $watchdogMinutes = $approachMinutes + $startupLag + self::WATCHDOG_MARGIN_MINUTES;
+        $watchdogTimestamp = $this->roundToMinuteBoundary(
+            time() + (int) ($watchdogMinutes * 60)
+        );
+        $this->scheduleWatchdog($watchdogTimestamp);
+
         // Record in state so subsequent checks use 1-minute scheduling
         $state['approach_check_at'] = (new \DateTimeImmutable(
             '@' . $approachTimestamp
@@ -673,6 +679,73 @@ class TargetTemperatureService
     public function cleanupCronJobs(): void
     {
         $this->crontabAdapter?->removeByPattern('HOTTUB:' . self::CRON_JOB_PREFIX);
+    }
+
+    /**
+     * Schedule a watchdog cron that will turn off the heater if the normal
+     * check chain fails. Uses the full /api/equipment/heater/off endpoint
+     * for logging and status updates.
+     *
+     * The watchdog is NOT cleaned up by stop() — it intentionally survives
+     * normal session completion as a second IFTTT off attempt. It IS cleaned
+     * up by HeaterControlService::heaterOn() (any new heater-on event).
+     */
+    private function scheduleWatchdog(int $timestamp): void
+    {
+        if ($this->cronSchedulingService === null || $this->cronRunnerPath === null || $this->apiBaseUrl === null) {
+            return;
+        }
+
+        $jobId = self::WATCHDOG_JOB_PREFIX . '-' . bin2hex(random_bytes(4));
+
+        $this->createWatchdogJobFile($jobId);
+
+        $command = sprintf(
+            '%s %s',
+            escapeshellarg($this->cronRunnerPath),
+            escapeshellarg($jobId)
+        );
+        $comment = sprintf('HOTTUB:%s:%s:ONCE', $jobId, 'WATCHDOG');
+
+        $this->cronSchedulingService->scheduleAt($timestamp, $command, $comment);
+    }
+
+    /**
+     * Create a watchdog job file that calls the heater-off endpoint.
+     */
+    private function createWatchdogJobFile(string $jobId): void
+    {
+        $jobsDir = dirname(dirname($this->stateFile)) . '/scheduled-jobs';
+        if (!is_dir($jobsDir)) {
+            mkdir($jobsDir, 0755, true);
+        }
+
+        $jobData = [
+            'jobId' => $jobId,
+            'endpoint' => '/api/equipment/heater/off?source=watchdog',
+            'apiBaseUrl' => rtrim($this->apiBaseUrl, '/'),
+            'recurring' => false,
+            'createdAt' => (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))->format('c'),
+        ];
+
+        $jobFile = $jobsDir . '/' . $jobId . '.json';
+        file_put_contents($jobFile, json_encode($jobData, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * Remove all watchdog cron jobs and job files.
+     * Called by HeaterControlService::heaterOn() to clear watchdogs
+     * when a new heater-on event occurs.
+     */
+    public static function cleanupWatchdogCrons(CrontabAdapterInterface $crontabAdapter, ?string $jobsDir = null): void
+    {
+        $crontabAdapter->removeByPattern('HOTTUB:' . self::WATCHDOG_JOB_PREFIX);
+
+        if ($jobsDir !== null && is_dir($jobsDir)) {
+            foreach (glob($jobsDir . '/' . self::WATCHDOG_JOB_PREFIX . '-*.json') as $jobFile) {
+                unlink($jobFile);
+            }
+        }
     }
 
     /**

--- a/backend/tests/ApiTest.php
+++ b/backend/tests/ApiTest.php
@@ -7,6 +7,8 @@ namespace HotTub\Tests;
 use PHPUnit\Framework\TestCase;
 use HotTub\Controllers\EquipmentController;
 use HotTub\Contracts\IftttClientInterface;
+use HotTub\Services\EquipmentStatusService;
+use HotTub\Services\HeaterControlService;
 use HotTub\Services\IftttClient;
 use HotTub\Services\StubHttpClient;
 use HotTub\Services\ConsoleLogger;
@@ -32,9 +34,12 @@ class ApiTest extends TestCase
             new EventLogger($this->testLogFile)
         );
 
+        $statusFile = sys_get_temp_dir() . '/hot-tub-api-test-status-' . uniqid() . '.json';
+        $statusService = new EquipmentStatusService($statusFile);
+        $heaterControl = new HeaterControlService($this->iftttClient, $statusService);
         $this->controller = new EquipmentController(
             $this->testLogFile,
-            $this->iftttClient
+            $heaterControl
         );
     }
 

--- a/backend/tests/Controllers/EquipmentControllerTest.php
+++ b/backend/tests/Controllers/EquipmentControllerTest.php
@@ -7,6 +7,7 @@ namespace HotTub\Tests\Controllers;
 use PHPUnit\Framework\TestCase;
 use HotTub\Controllers\EquipmentController;
 use HotTub\Services\EquipmentStatusService;
+use HotTub\Services\HeaterControlService;
 use HotTub\Services\TargetTemperatureService;
 use HotTub\Contracts\IftttClientInterface;
 use HotTub\Contracts\CrontabAdapterInterface;
@@ -22,6 +23,7 @@ class EquipmentControllerTest extends TestCase
     private string $statusFile;
     private IftttClientInterface $mockIftttClient;
     private EquipmentStatusService $statusService;
+    private HeaterControlService $heaterControl;
 
     protected function setUp(): void
     {
@@ -30,6 +32,7 @@ class EquipmentControllerTest extends TestCase
 
         $this->mockIftttClient = $this->createMock(IftttClientInterface::class);
         $this->statusService = new EquipmentStatusService($this->statusFile);
+        $this->heaterControl = new HeaterControlService($this->mockIftttClient, $this->statusService);
     }
 
     protected function tearDown(): void
@@ -50,7 +53,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService
         );
 
@@ -71,7 +74,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService
         );
 
@@ -89,7 +92,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService
         );
 
@@ -107,7 +110,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService
         );
 
@@ -124,7 +127,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService
         );
 
@@ -146,7 +149,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService
         );
 
@@ -166,7 +169,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService
         );
 
@@ -191,7 +194,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService
         );
 
@@ -213,7 +216,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService
         );
 
@@ -253,7 +256,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService,
             $targetTempService
         );
@@ -303,7 +306,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService,
             $targetTempService
         );
@@ -331,7 +334,7 @@ class EquipmentControllerTest extends TestCase
         // Create controller WITHOUT TargetTemperatureService
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService
             // No targetTempService - should still work
         );
@@ -340,6 +343,74 @@ class EquipmentControllerTest extends TestCase
 
         $status = $this->statusService->getStatus();
         $this->assertFalse($status['heater']['on'], 'Heater should be off even without TargetTemperatureService');
+    }
+
+    // ========== Watchdog Source Tests ==========
+
+    public function testWatchdogHeaterOffLogsHeaterWasOn(): void
+    {
+        $this->mockIftttClient->method('trigger')->willReturn(true);
+        $this->mockIftttClient->method('getMode')->willReturn('stub');
+
+        // Heater is on (watchdog firing = something went wrong)
+        $this->statusService->setHeaterOn();
+
+        $controller = new EquipmentController(
+            $this->logFile,
+            $this->heaterControl,
+            $this->statusService
+        );
+
+        $response = $controller->heaterOff('watchdog');
+
+        $this->assertEquals(200, $response['status']);
+        $this->assertEquals('watchdog', $response['body']['source']);
+
+        // Check event log for watchdog entry with heater_was_on
+        $logContents = file_get_contents($this->logFile);
+        $this->assertStringContainsString('watchdog_heater_off', $logContents);
+        $this->assertStringContainsString('"heater_was_on":true', $logContents);
+    }
+
+    public function testWatchdogHeaterOffLogsHeaterWasOff(): void
+    {
+        $this->mockIftttClient->method('trigger')->willReturn(true);
+        $this->mockIftttClient->method('getMode')->willReturn('stub');
+
+        // Heater is already off (normal case — session completed before watchdog fired)
+        $controller = new EquipmentController(
+            $this->logFile,
+            $this->heaterControl,
+            $this->statusService
+        );
+
+        $response = $controller->heaterOff('watchdog');
+
+        $this->assertEquals(200, $response['status']);
+        $this->assertEquals('watchdog', $response['body']['source']);
+
+        $logContents = file_get_contents($this->logFile);
+        $this->assertStringContainsString('watchdog_heater_off', $logContents);
+        $this->assertStringContainsString('"heater_was_on":false', $logContents);
+    }
+
+    public function testNormalHeaterOffDoesNotIncludeWatchdogSource(): void
+    {
+        $this->mockIftttClient->method('trigger')->willReturn(true);
+        $this->mockIftttClient->method('getMode')->willReturn('stub');
+
+        $controller = new EquipmentController(
+            $this->logFile,
+            $this->heaterControl,
+            $this->statusService
+        );
+
+        $response = $controller->heaterOff();
+
+        $this->assertArrayNotHasKey('source', $response['body']);
+
+        $logContents = file_get_contents($this->logFile);
+        $this->assertStringNotContainsString('watchdog_heater_off', $logContents);
     }
 
     // ========== Pump Run Tests ==========
@@ -351,7 +422,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService
         );
 
@@ -368,7 +439,7 @@ class EquipmentControllerTest extends TestCase
 
         $controller = new EquipmentController(
             $this->logFile,
-            $this->mockIftttClient,
+            $this->heaterControl,
             $this->statusService
         );
 

--- a/backend/tests/Integration/HeatToTargetCronChainTest.php
+++ b/backend/tests/Integration/HeatToTargetCronChainTest.php
@@ -7,6 +7,7 @@ namespace HotTub\Tests\Integration;
 use HotTub\Services\CrontabAdapter;
 use HotTub\Services\EquipmentStatusService;
 use HotTub\Services\Esp32TemperatureService;
+use HotTub\Services\HeaterControlService;
 use HotTub\Services\SchedulerService;
 use HotTub\Services\TargetTemperatureService;
 use HotTub\Tests\Fixtures\HeatingCycleFixture;
@@ -142,9 +143,10 @@ class HeatToTargetCronChainTest extends TestCase
             $cronEntries[] = $entry;
         });
 
+        $heaterControl = new HeaterControlService($mockIfttt, $this->equipmentStatus);
         $service = new TargetTemperatureService(
             $this->targetTempFile,
-            $mockIfttt,
+            $heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp,
             $mockCrontab,
@@ -254,9 +256,10 @@ class HeatToTargetCronChainTest extends TestCase
         $mockIfttt = $this->createMock(\HotTub\Contracts\IftttClientInterface::class);
         $mockIfttt->method('trigger')->willReturn(true);
 
+        $heaterControl = new HeaterControlService($mockIfttt, $this->equipmentStatus);
         $service = new TargetTemperatureService(
             $this->targetTempFile,
-            $mockIfttt,
+            $heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp,
             $mockCrontab,
@@ -310,9 +313,10 @@ class HeatToTargetCronChainTest extends TestCase
         $mockIfttt = $this->createMock(\HotTub\Contracts\IftttClientInterface::class);
         $mockIfttt->method('trigger')->willReturn(true);
 
+        $heaterControl = new HeaterControlService($mockIfttt, $this->equipmentStatus);
         $service = new TargetTemperatureService(
             $this->targetTempFile,
-            $mockIfttt,
+            $heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp,
             $mockCrontab,
@@ -499,9 +503,10 @@ class HeatToTargetCronChainTest extends TestCase
         $mockIfttt = $this->createMock(\HotTub\Contracts\IftttClientInterface::class);
         $mockIfttt->method('trigger')->willReturn(true);
 
+        $heaterControl = new HeaterControlService($mockIfttt, $this->equipmentStatus);
         $service = new TargetTemperatureService(
             $this->targetTempFile,
-            $mockIfttt,
+            $heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp,
             $mockCrontab,

--- a/backend/tests/Integration/TargetTemperatureIntegrationTest.php
+++ b/backend/tests/Integration/TargetTemperatureIntegrationTest.php
@@ -8,6 +8,7 @@ use HotTub\Contracts\CrontabAdapterInterface;
 use HotTub\Contracts\IftttClientInterface;
 use HotTub\Services\EquipmentStatusService;
 use HotTub\Services\Esp32TemperatureService;
+use HotTub\Services\HeaterControlService;
 use HotTub\Services\TargetTemperatureService;
 use HotTub\Tests\Fixtures\HeatingCycleFixture;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -43,9 +44,10 @@ class TargetTemperatureIntegrationTest extends TestCase
         $this->equipmentStatus = new EquipmentStatusService($this->equipmentStatusFile);
         $this->esp32Temp = new Esp32TemperatureService($this->esp32TempFile, $this->equipmentStatus);
 
+        $heaterControl = new HeaterControlService($this->mockIfttt, $this->equipmentStatus);
         $this->service = new TargetTemperatureService(
             $this->stateFile,
-            $this->mockIfttt,
+            $heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp,
             $this->mockCrontab,

--- a/backend/tests/Services/HeaterControlServiceTest.php
+++ b/backend/tests/Services/HeaterControlServiceTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Tests\Services;
+
+use HotTub\Contracts\CrontabAdapterInterface;
+use HotTub\Contracts\IftttClientInterface;
+use HotTub\Services\EquipmentStatusService;
+use HotTub\Services\HeaterControlService;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class HeaterControlServiceTest extends TestCase
+{
+    private MockObject&IftttClientInterface $mockIfttt;
+    private MockObject&CrontabAdapterInterface $mockCrontab;
+    private string $statusFile;
+    private EquipmentStatusService $statusService;
+
+    protected function setUp(): void
+    {
+        $this->mockIfttt = $this->createMock(IftttClientInterface::class);
+        $this->mockCrontab = $this->createMock(CrontabAdapterInterface::class);
+        $this->statusFile = sys_get_temp_dir() . '/heater-control-test-' . uniqid() . '.json';
+        $this->statusService = new EquipmentStatusService($this->statusFile);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->statusFile)) {
+            unlink($this->statusFile);
+        }
+    }
+
+    private function createService(): HeaterControlService
+    {
+        return new HeaterControlService($this->mockIfttt, $this->statusService);
+    }
+
+    private function createServiceWithWatchdogCleanup(?string $jobsDir = null): HeaterControlService
+    {
+        return new HeaterControlService(
+            $this->mockIfttt,
+            $this->statusService,
+            $this->mockCrontab,
+            $jobsDir
+        );
+    }
+
+    public function testHeaterOnTriggersIftttAndUpdatesStatus(): void
+    {
+        $this->mockIfttt->expects($this->once())
+            ->method('trigger')
+            ->with('hot-tub-heat-on')
+            ->willReturn(true);
+
+        $service = $this->createService();
+        $result = $service->heaterOn();
+
+        $this->assertTrue($result);
+        $status = $this->statusService->getStatus();
+        $this->assertTrue($status['heater']['on']);
+    }
+
+    public function testHeaterOnDoesNotUpdateStatusOnFailure(): void
+    {
+        $this->mockIfttt->expects($this->once())
+            ->method('trigger')
+            ->with('hot-tub-heat-on')
+            ->willReturn(false);
+
+        $service = $this->createService();
+        $result = $service->heaterOn();
+
+        $this->assertFalse($result);
+        $status = $this->statusService->getStatus();
+        $this->assertFalse($status['heater']['on']);
+    }
+
+    public function testHeaterOffTriggersIftttAndUpdatesStatus(): void
+    {
+        // Start with heater on
+        $this->statusService->setHeaterOn();
+        $this->statusService->setPumpOn();
+
+        $this->mockIfttt->expects($this->once())
+            ->method('trigger')
+            ->with('hot-tub-heat-off')
+            ->willReturn(true);
+
+        $service = $this->createService();
+        $result = $service->heaterOff();
+
+        $this->assertTrue($result);
+        $status = $this->statusService->getStatus();
+        $this->assertFalse($status['heater']['on']);
+        $this->assertFalse($status['pump']['on'], 'Pump should also be turned off with heater');
+    }
+
+    public function testHeaterOffDoesNotUpdateStatusOnFailure(): void
+    {
+        // Start with heater on
+        $this->statusService->setHeaterOn();
+
+        $this->mockIfttt->expects($this->once())
+            ->method('trigger')
+            ->with('hot-tub-heat-off')
+            ->willReturn(false);
+
+        $service = $this->createService();
+        $result = $service->heaterOff();
+
+        $this->assertFalse($result);
+        $status = $this->statusService->getStatus();
+        $this->assertTrue($status['heater']['on'], 'Heater should remain on after IFTTT failure');
+    }
+
+    public function testPumpRunTriggersIftttAndUpdatesStatus(): void
+    {
+        $this->mockIfttt->expects($this->once())
+            ->method('trigger')
+            ->with('cycle_hot_tub_ionizer')
+            ->willReturn(true);
+
+        $service = $this->createService();
+        $result = $service->pumpRun();
+
+        $this->assertTrue($result);
+        $status = $this->statusService->getStatus();
+        $this->assertTrue($status['pump']['on']);
+    }
+
+    // ========== Watchdog cleanup tests ==========
+
+    public function testHeaterOnCleansUpWatchdogCrons(): void
+    {
+        $this->mockIfttt->method('trigger')->willReturn(true);
+
+        $this->mockCrontab->expects($this->once())
+            ->method('removeByPattern')
+            ->with('HOTTUB:watchdog');
+
+        $service = $this->createServiceWithWatchdogCleanup();
+        $service->heaterOn();
+    }
+
+    public function testHeaterOnCleansUpWatchdogJobFiles(): void
+    {
+        $this->mockIfttt->method('trigger')->willReturn(true);
+        $this->mockCrontab->method('removeByPattern');
+
+        // Create a temp jobs dir with watchdog files
+        $jobsDir = sys_get_temp_dir() . '/watchdog-cleanup-test-' . uniqid();
+        mkdir($jobsDir, 0755, true);
+
+        $watchdogFile = $jobsDir . '/watchdog-abc12345.json';
+        file_put_contents($watchdogFile, json_encode(['jobId' => 'watchdog-abc12345']));
+
+        // Non-watchdog file should survive
+        $otherFile = $jobsDir . '/heat-target-xyz.json';
+        file_put_contents($otherFile, json_encode(['jobId' => 'heat-target-xyz']));
+
+        $service = $this->createServiceWithWatchdogCleanup($jobsDir);
+        $service->heaterOn();
+
+        $this->assertFileDoesNotExist($watchdogFile, 'Watchdog job file should be cleaned on heaterOn()');
+        $this->assertFileExists($otherFile, 'Non-watchdog job file should survive');
+
+        // Cleanup
+        unlink($otherFile);
+        rmdir($jobsDir);
+    }
+
+    public function testHeaterOffDoesNotCleanUpWatchdogCrons(): void
+    {
+        $this->mockIfttt->method('trigger')->willReturn(true);
+
+        // removeByPattern should NOT be called for watchdog on heaterOff
+        $this->mockCrontab->expects($this->never())
+            ->method('removeByPattern');
+
+        $service = $this->createServiceWithWatchdogCleanup();
+        $service->heaterOff();
+    }
+
+    public function testHeaterOnFailureStillCleansUpWatchdog(): void
+    {
+        // Even if IFTTT fails, watchdog should still be cleaned
+        // (the heater-on intent was expressed, just failed to execute)
+        $this->mockIfttt->method('trigger')->willReturn(false);
+
+        $this->mockCrontab->expects($this->once())
+            ->method('removeByPattern')
+            ->with('HOTTUB:watchdog');
+
+        $service = $this->createServiceWithWatchdogCleanup();
+        $service->heaterOn();
+    }
+}

--- a/backend/tests/Services/TargetTemperatureServiceTest.php
+++ b/backend/tests/Services/TargetTemperatureServiceTest.php
@@ -9,6 +9,7 @@ use HotTub\Contracts\IftttClientInterface;
 use HotTub\Services\EquipmentStatusService;
 use HotTub\Services\Esp32TemperatureService;
 use HotTub\Services\Esp32SensorConfigService;
+use HotTub\Services\HeaterControlService;
 use HotTub\Services\HeatTargetSettingsService;
 use HotTub\Services\CronSchedulingService;
 use HotTub\Services\TargetTemperatureService;
@@ -24,6 +25,7 @@ class TargetTemperatureServiceTest extends TestCase
     private MockObject&IftttClientInterface $mockIfttt;
     private MockObject&CrontabAdapterInterface $mockCrontab;
     private EquipmentStatusService $equipmentStatus;
+    private HeaterControlService $heaterControl;
     private Esp32TemperatureService $esp32Temp;
     private Esp32SensorConfigService $esp32Config;
 
@@ -37,6 +39,7 @@ class TargetTemperatureServiceTest extends TestCase
         $this->mockIfttt = $this->createMock(IftttClientInterface::class);
         $this->mockCrontab = $this->createMock(CrontabAdapterInterface::class);
         $this->equipmentStatus = new EquipmentStatusService($this->equipmentStatusFile);
+        $this->heaterControl = new HeaterControlService($this->mockIfttt, $this->equipmentStatus);
         $this->esp32Temp = new Esp32TemperatureService($this->esp32TempFile, $this->equipmentStatus);
         $this->esp32Config = new Esp32SensorConfigService($this->esp32ConfigFile);
     }
@@ -56,7 +59,7 @@ class TargetTemperatureServiceTest extends TestCase
     {
         return new TargetTemperatureService(
             $this->stateFile,
-            $this->mockIfttt,
+            $this->heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp
         );
@@ -66,7 +69,7 @@ class TargetTemperatureServiceTest extends TestCase
     {
         return new TargetTemperatureService(
             $this->stateFile,
-            $this->mockIfttt,
+            $this->heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp,
             $this->mockCrontab,
@@ -759,7 +762,7 @@ class TargetTemperatureServiceTest extends TestCase
     {
         return new TargetTemperatureService(
             $this->stateFile,
-            $this->mockIfttt,
+            $this->heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp,
             null, // crontab
@@ -851,7 +854,7 @@ class TargetTemperatureServiceTest extends TestCase
     ): TargetTemperatureService {
         return new TargetTemperatureService(
             $this->stateFile,
-            $this->mockIfttt,
+            $this->heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp,
             $this->mockCrontab,
@@ -1090,7 +1093,7 @@ class TargetTemperatureServiceTest extends TestCase
     ): TargetTemperatureService {
         return new TargetTemperatureService(
             $this->stateFile,
-            $this->mockIfttt,
+            $this->heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp,
             $this->mockCrontab,
@@ -1251,7 +1254,7 @@ class TargetTemperatureServiceTest extends TestCase
     ): TargetTemperatureService {
         return new TargetTemperatureService(
             $this->stateFile,
-            $this->mockIfttt,
+            $this->heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp,
             $this->mockCrontab,
@@ -1373,7 +1376,7 @@ class TargetTemperatureServiceTest extends TestCase
 
         return new TargetTemperatureService(
             $this->stateFile,
-            $this->mockIfttt,
+            $this->heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp,
             $this->mockCrontab,
@@ -1399,10 +1402,10 @@ class TargetTemperatureServiceTest extends TestCase
 
         $service->start(102.0);
 
-        // Should have exactly 1 cron entry (the approach check)
-        $this->assertCount(1, $capturedTimestamps, 'Expected exactly 1 cron entry (approach check)');
+        // Should have 2 cron entries: approach check + watchdog
+        $this->assertCount(2, $capturedTimestamps, 'Expected approach check + watchdog');
 
-        // The cron should be scheduled ~30 min from now, not ~1 min
+        // The first cron (approach) should be scheduled ~30 min from now, not ~1 min
         $diffMinutes = ($capturedTimestamps[0] - time()) / 60;
         $this->assertGreaterThanOrEqual(25, $diffMinutes, 'Approach check should be ~30 min out, not 1 min');
         $this->assertLessThanOrEqual(35, $diffMinutes, 'Approach check should be ~30 min out');
@@ -1426,6 +1429,7 @@ class TargetTemperatureServiceTest extends TestCase
 
         $this->assertNotEmpty($capturedTimestamps);
 
+        // First entry is the approach check
         $diffMinutes = ($capturedTimestamps[0] - time()) / 60;
         // Must be closer to 30 than to 35 (lag should NOT be included)
         $this->assertLessThanOrEqual(33, $diffMinutes, 'Approach check should exclude startup lag');
@@ -1498,5 +1502,192 @@ class TargetTemperatureServiceTest extends TestCase
         // Should be 1-2 min from now (minute chain), not a far-future approach
         $diffMinutes = ($capturedTimestamps[0] - time()) / 60;
         $this->assertLessThanOrEqual(3, $diffMinutes, 'After approach fired, should use 1-min scheduling');
+    }
+
+    // ========================================================================
+    // Watchdog Cron Tests
+    // ========================================================================
+
+    /**
+     * Helper: create a service with smart scheduling that captures both
+     * timestamps and cron comments, so we can distinguish approach vs watchdog entries.
+     *
+     * @param array<int, array{timestamp: int, comment: string}> &$capturedEntries
+     */
+    private function createServiceWithWatchdogTracking(
+        ?string $heatingCharsFile,
+        array &$capturedEntries
+    ): TargetTemperatureService {
+        $mockCronScheduling = $this->createMock(CronSchedulingService::class);
+        $mockCronScheduling->method('scheduleAt')
+            ->willReturnCallback(function (int $timestamp, string $command, string $comment) use (&$capturedEntries) {
+                $capturedEntries[] = ['timestamp' => $timestamp, 'comment' => $comment];
+                return '0 0 * * *';
+            });
+
+        return new TargetTemperatureService(
+            $this->stateFile,
+            $this->heaterControl,
+            $this->equipmentStatus,
+            $this->esp32Temp,
+            $this->mockCrontab,
+            '/path/to/cron-runner.sh',
+            'https://example.com/api',
+            $this->esp32Config,
+            $mockCronScheduling,
+            null, // heatTargetSettings
+            null, // stallEventFile
+            null, // equipmentEventLogFile
+            $heatingCharsFile
+        );
+    }
+
+    public function testWatchdogScheduledWithSmartApproach(): void
+    {
+        // velocity=0.4 F/min, lag=5 min. Current=90, target=102.
+        // Approach time = (102-90)/0.4 = 30 min (no lag)
+        // Watchdog time = 30 + 5 (lag) + 10 (margin) = 45 min
+        $charsFile = $this->createHeatingCharacteristicsFile(0.4, 5.0);
+        $capturedEntries = [];
+        $service = $this->createServiceWithWatchdogTracking($charsFile, $capturedEntries);
+        $this->storeEsp32Reading(90.0);
+
+        $service->start(102.0);
+
+        // Should have 2 cron entries: approach check + watchdog
+        $this->assertCount(2, $capturedEntries, 'Expected approach check + watchdog');
+
+        // Find the watchdog entry by comment pattern
+        $watchdogEntries = array_filter($capturedEntries, fn($e) => str_contains($e['comment'], 'WATCHDOG'));
+        $this->assertCount(1, $watchdogEntries, 'Expected exactly 1 watchdog entry');
+
+        $watchdog = array_values($watchdogEntries)[0];
+
+        // Watchdog should be ~45 min from now (approach 30 + lag 5 + margin 10)
+        $diffMinutes = ($watchdog['timestamp'] - time()) / 60;
+        $this->assertGreaterThanOrEqual(40, $diffMinutes, 'Watchdog should be ~45 min out');
+        $this->assertLessThanOrEqual(50, $diffMinutes, 'Watchdog should be ~45 min out');
+
+        // Comment should use watchdog prefix
+        $this->assertStringContainsString('HOTTUB:watchdog-', $watchdog['comment']);
+    }
+
+    public function testWatchdogNotScheduledWithoutSmartApproach(): void
+    {
+        // No characteristics → no smart approach → no watchdog
+        $capturedEntries = [];
+        $service = $this->createServiceWithWatchdogTracking(null, $capturedEntries);
+        $this->storeEsp32Reading(90.0);
+
+        $service->start(102.0);
+
+        // Should have only legacy 1-min check, no watchdog
+        $watchdogEntries = array_filter($capturedEntries, fn($e) => str_contains($e['comment'], 'WATCHDOG'));
+        $this->assertCount(0, $watchdogEntries, 'No watchdog without smart approach');
+    }
+
+    public function testWatchdogJobFileHasHeaterOffEndpoint(): void
+    {
+        // Set up directory structure for job files
+        $tempDir = sys_get_temp_dir() . '/watchdog-jobfile-test-' . uniqid();
+        $stateDir = $tempDir . '/state';
+        $jobsDir = $tempDir . '/scheduled-jobs';
+        mkdir($stateDir, 0755, true);
+        mkdir($jobsDir, 0755, true);
+
+        $stateFile = $stateDir . '/target-temperature.json';
+        $charsFile = $this->createHeatingCharacteristicsFile(0.4, 5.0);
+
+        $mockCronScheduling = $this->createMock(CronSchedulingService::class);
+        $mockCronScheduling->method('scheduleAt')->willReturn('0 0 * * *');
+
+        $service = new TargetTemperatureService(
+            $stateFile,
+            $this->heaterControl,
+            $this->equipmentStatus,
+            $this->esp32Temp,
+            $this->mockCrontab,
+            '/path/to/cron-runner.sh',
+            'https://example.com/api',
+            $this->esp32Config,
+            $mockCronScheduling,
+            null, null, null,
+            $charsFile
+        );
+
+        $this->storeEsp32Reading(90.0);
+        $service->start(102.0);
+
+        // Find watchdog job file
+        $watchdogFiles = glob($jobsDir . '/watchdog-*.json');
+        $this->assertNotEmpty($watchdogFiles, 'Watchdog job file should be created');
+
+        $jobData = json_decode(file_get_contents($watchdogFiles[0]), true);
+        $this->assertEquals('/api/equipment/heater/off?source=watchdog', $jobData['endpoint']);
+
+        // Cleanup
+        foreach (glob($jobsDir . '/*.json') as $f) { unlink($f); }
+        // Clean up lock file if exists
+        $lockFile = $stateDir . '/target-temperature.lock';
+        if (file_exists($lockFile)) { unlink($lockFile); }
+        if (file_exists($stateFile)) { unlink($stateFile); }
+        rmdir($jobsDir);
+        rmdir($stateDir);
+        rmdir($tempDir);
+    }
+
+    public function testStopDoesNotCleanUpWatchdogCrons(): void
+    {
+        // stop() should only clean heat-target crons, NOT watchdog crons
+        $this->mockCrontab->expects($this->atLeastOnce())
+            ->method('removeByPattern')
+            ->with($this->callback(function (string $pattern) {
+                // Should only be called with heat-target pattern, never watchdog
+                $this->assertStringContainsString('heat-target', $pattern);
+                $this->assertStringNotContainsString('watchdog', $pattern);
+                return true;
+            }));
+
+        $service = $this->createServiceWithCron();
+        $service->start(103.5);
+        $service->stop();
+    }
+
+    public function testStopDoesNotCleanUpWatchdogJobFiles(): void
+    {
+        // Set up directory structure
+        $tempDir = sys_get_temp_dir() . '/watchdog-stop-test-' . uniqid();
+        $stateDir = $tempDir . '/state';
+        $jobsDir = $tempDir . '/scheduled-jobs';
+        mkdir($stateDir, 0755, true);
+        mkdir($jobsDir, 0755, true);
+
+        $stateFile = $stateDir . '/target-temperature.json';
+
+        // Create a watchdog job file (simulates one created during start)
+        $watchdogJobFile = $jobsDir . '/watchdog-abc12345.json';
+        file_put_contents($watchdogJobFile, json_encode(['jobId' => 'watchdog-abc12345']));
+
+        // Also create a heat-target job file (should be cleaned)
+        $heatTargetJobFile = $jobsDir . '/heat-target-def67890.json';
+        file_put_contents($heatTargetJobFile, json_encode(['jobId' => 'heat-target-def67890']));
+
+        $service = new TargetTemperatureService($stateFile);
+        $service->start(103.5);
+        $service->stop();
+
+        // Watchdog job file should survive stop()
+        $this->assertFileExists($watchdogJobFile, 'Watchdog job file should NOT be deleted by stop()');
+        // Heat-target job file should be cleaned
+        $this->assertFileDoesNotExist($heatTargetJobFile, 'Heat-target job file should be deleted');
+
+        // Cleanup
+        if (file_exists($watchdogJobFile)) { unlink($watchdogJobFile); }
+        $lockFile = $stateDir . '/target-temperature.lock';
+        if (file_exists($lockFile)) { unlink($lockFile); }
+        if (file_exists($stateFile)) { unlink($stateFile); }
+        rmdir($jobsDir);
+        rmdir($stateDir);
+        rmdir($tempDir);
     }
 }

--- a/backend/tests/Services/TargetTemperatureStallDetectionTest.php
+++ b/backend/tests/Services/TargetTemperatureStallDetectionTest.php
@@ -8,6 +8,7 @@ use HotTub\Contracts\CrontabAdapterInterface;
 use HotTub\Contracts\IftttClientInterface;
 use HotTub\Services\EquipmentStatusService;
 use HotTub\Services\Esp32TemperatureService;
+use HotTub\Services\HeaterControlService;
 use HotTub\Services\HeatTargetSettingsService;
 use HotTub\Services\TargetTemperatureService;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -24,6 +25,7 @@ class TargetTemperatureStallDetectionTest extends TestCase
     private MockObject&IftttClientInterface $mockIfttt;
     private MockObject&CrontabAdapterInterface $mockCrontab;
     private EquipmentStatusService $equipmentStatus;
+    private HeaterControlService $heaterControl;
     private Esp32TemperatureService $esp32Temp;
     private HeatTargetSettingsService $heatTargetSettings;
 
@@ -45,6 +47,7 @@ class TargetTemperatureStallDetectionTest extends TestCase
         $this->mockIfttt = $this->createMock(IftttClientInterface::class);
         $this->mockCrontab = $this->createMock(CrontabAdapterInterface::class);
         $this->equipmentStatus = new EquipmentStatusService($this->equipmentStatusFile);
+        $this->heaterControl = new HeaterControlService($this->mockIfttt, $this->equipmentStatus);
         $this->esp32Temp = new Esp32TemperatureService($this->esp32TempFile, $this->equipmentStatus);
         $this->heatTargetSettings = new HeatTargetSettingsService($this->settingsFile);
     }
@@ -78,7 +81,7 @@ class TargetTemperatureStallDetectionTest extends TestCase
     {
         return new TargetTemperatureService(
             $this->stateFile,
-            $this->mockIfttt,
+            $this->heaterControl,
             $this->equipmentStatus,
             $this->esp32Temp,
             $this->mockCrontab,


### PR DESCRIPTION
## Summary
- Consolidate all IFTTT hardware triggers into `HeaterControlService` — single code path for heater on/off/pump with consistent success checking and status updates
- Add watchdog safety cron: redundant heater-off scheduled at `expectedCompletion + startupLag + 10min` during heat-to-target sessions
- Watchdog survives normal session completion (different cron prefix), cleared on any new heater-on event
- Watchdog calls `/api/equipment/heater/off?source=watchdog` which logs whether heater was unexpectedly still on

## Test plan
- [x] All 930 backend PHPUnit tests pass
- [x] All 123 Playwright E2E tests pass
- [x] All frontend unit tests pass
- [x] Watchdog scheduling verified with smart approach timing
- [x] Watchdog cleanup verified on heaterOn()
- [x] stop() confirmed NOT to clean up watchdog crons (intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)