### PR TITLE
Deploy: read-only role + DB-backed JWT validation

### DIFF
--- a/backend/bin/mint-jwt.php
+++ b/backend/bin/mint-jwt.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Mint a JWT for a given subject/role/expiry and print it to stdout.
+ *
+ * Unlike bin/generate-cron-jwt.php (which writes CRON_JWT into .env), this prints
+ * the token so it can be installed into an external client such as Home Assistant.
+ * The JWT_SECRET is read from the backend .env file.
+ *
+ * Usage:
+ *   php bin/mint-jwt.php --sub=homeassistant --role=readonly --years=10 [--env=/path/to/.env]
+ *
+ * IMPORTANT: DB-backed validation requires the subject to exist as a user whose
+ * role matches the token's role. Provision the user first (e.g. an admin calling
+ * POST /api/users with {"username":"homeassistant","role":"readonly", ...}), or the
+ * token will be rejected with 401.
+ */
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Firebase\JWT\JWT;
+
+/**
+ * Build a signed JWT for the given subject, role and expiry.
+ */
+function mintJwt(string $jwtSecret, string $sub, string $role, int $years): string
+{
+    $payload = [
+        'iat' => time(),
+        'exp' => time() + ($years * 365 * 24 * 60 * 60),
+        'sub' => $sub,
+        'role' => $role,
+    ];
+
+    return JWT::encode($payload, $jwtSecret, 'HS256');
+}
+
+/**
+ * Read JWT_SECRET from an .env file.
+ *
+ * @return array{success: bool, secret?: string, message?: string}
+ */
+function readJwtSecret(string $envPath): array
+{
+    if (!file_exists($envPath)) {
+        return ['success' => false, 'message' => 'Env file not found: ' . $envPath];
+    }
+
+    $envContent = file_get_contents($envPath);
+    if (!preg_match('/^JWT_SECRET=(.+)$/m', $envContent, $matches)) {
+        return ['success' => false, 'message' => 'JWT_SECRET not found in ' . $envPath];
+    }
+
+    return ['success' => true, 'secret' => trim($matches[1])];
+}
+
+// Run if executed directly (not included/required by a test).
+if (php_sapi_name() === 'cli' && isset($argv[0]) && realpath($argv[0]) === realpath(__FILE__)) {
+    $opts = getopt('', ['sub:', 'role:', 'years::', 'env::']);
+
+    $sub = $opts['sub'] ?? null;
+    $role = $opts['role'] ?? null;
+    $years = (int) ($opts['years'] ?? 10);
+    $envPath = $opts['env'] ?? (dirname(__DIR__) . '/.env');
+
+    if ($sub === null || $role === null) {
+        fwrite(STDERR, "Usage: php bin/mint-jwt.php --sub=<name> --role=<role> [--years=N] [--env=/path/.env]\n");
+        exit(1);
+    }
+
+    $secretResult = readJwtSecret($envPath);
+    if (!$secretResult['success']) {
+        fwrite(STDERR, "✗ Error: {$secretResult['message']}\n");
+        exit(1);
+    }
+
+    $token = mintJwt($secretResult['secret'], $sub, $role, $years);
+
+    echo "Minted JWT (sub=$sub, role=$role, expires in $years years):\n\n";
+    echo $token . "\n\n";
+
+    // Print decoded claims for verification (payload is the middle segment).
+    $payloadSegment = explode('.', $token)[1];
+    $claims = json_decode(base64_decode(strtr($payloadSegment, '-_', '+/')), true);
+    echo "Decoded claims:\n";
+    echo json_encode($claims, JSON_PRETTY_PRINT) . "\n\n";
+    echo "Reminder: user '$sub' must exist with role '$role' for this token to validate.\n";
+    exit(0);
+}

--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -243,6 +243,7 @@ $cookies = $_COOKIE;
 // Auth middleware for protected routes
 $requireAuth = fn() => $authMiddleware->requireAuth($headers, $cookies);
 $requireAdmin = fn() => $authMiddleware->requireAdmin($headers, $cookies);
+$requireWrite = fn() => $authMiddleware->requireWrite($headers, $cookies);
 
 // Configure routes
 $router = new Router();
@@ -276,19 +277,19 @@ $router->post('/api/auth/login', fn() => handleLogin($authController, $config, $
 $router->post('/api/auth/logout', fn() => handleLogout($authController, $cookieHelper));
 $router->get('/api/auth/me', fn() => handleMe($authController, $headers, $cookies));
 
-// Protected equipment routes (with auth middleware)
-$router->post('/api/equipment/heater/on', fn() => $equipmentController->heaterOn(), $requireAuth);
-$router->post('/api/equipment/heater/off', fn() => $equipmentController->heaterOff($_GET['source'] ?? null), $requireAuth);
-$router->post('/api/equipment/pump/run', fn() => $equipmentController->pumpRun(), $requireAuth);
+// Protected equipment routes (mutating → requireWrite; readonly tokens are denied)
+$router->post('/api/equipment/heater/on', fn() => $equipmentController->heaterOn(), $requireWrite);
+$router->post('/api/equipment/heater/off', fn() => $equipmentController->heaterOff($_GET['source'] ?? null), $requireWrite);
+$router->post('/api/equipment/pump/run', fn() => $equipmentController->pumpRun(), $requireWrite);
 
 // Target temperature routes (heat to specific temperature)
-$router->post('/api/equipment/heat-to-target', fn() => handleHeatToTarget($targetTemperatureController), $requireAuth);
+$router->post('/api/equipment/heat-to-target', fn() => handleHeatToTarget($targetTemperatureController), $requireWrite);
 $router->get('/api/equipment/heat-to-target', fn() => $targetTemperatureController->status(), $requireAuth);
-$router->delete('/api/equipment/heat-to-target', fn() => $targetTemperatureController->cancel(), $requireAuth);
+$router->delete('/api/equipment/heat-to-target', fn() => $targetTemperatureController->cancel(), $requireWrite);
 
 // Protected blinds routes (optional feature - returns 404 if not enabled)
-$router->post('/api/blinds/open', fn() => $blindsController->open(), $requireAuth);
-$router->post('/api/blinds/close', fn() => $blindsController->close(), $requireAuth);
+$router->post('/api/blinds/open', fn() => $blindsController->open(), $requireWrite);
+$router->post('/api/blinds/close', fn() => $blindsController->close(), $requireWrite);
 
 // Protected temperature routes (with auth middleware)
 $router->get('/api/temperature', fn() => $temperatureController->get(), $requireAuth);
@@ -299,19 +300,19 @@ $router->get('/api/temperature/all', fn() => $temperatureController->getAll(), $
 
 // ESP32 sensor configuration endpoints (require auth)
 $router->get('/api/esp32/sensors', fn() => $esp32SensorConfigController->list(), $requireAuth);
-$router->put('/api/esp32/sensors/{address}', fn($params) => handleEsp32SensorUpdate($esp32SensorConfigController, $params['address']), $requireAuth);
+$router->put('/api/esp32/sensors/{address}', fn($params) => handleEsp32SensorUpdate($esp32SensorConfigController, $params['address']), $requireWrite);
 
 // Heat-target settings endpoints
 $router->get('/api/settings/heat-target', fn() => $heatTargetSettingsController->get(), $requireAuth);
 $router->put('/api/settings/heat-target', fn() => handleHeatTargetSettingsUpdate($heatTargetSettingsController), $requireAdmin);
 
-// Protected schedule routes (with auth middleware)
-$router->post('/api/schedule', fn() => handleScheduleCreate($scheduleController), $requireAuth);
+// Protected schedule routes (reads → requireAuth; mutations → requireWrite)
+$router->post('/api/schedule', fn() => handleScheduleCreate($scheduleController), $requireWrite);
 $router->get('/api/schedule', fn() => $scheduleController->list(), $requireAuth);
-$router->delete('/api/schedule/{id}', fn($params) => $scheduleController->cancel($params['id']), $requireAuth);
-$router->put('/api/schedule/{id}/target-temp', fn($params) => handleScheduleUpdateTargetTemp($scheduleController, $params['id']), $requireAuth);
-$router->post('/api/schedule/{id}/skip', fn($params) => $scheduleController->skip($params['id']), $requireAuth);
-$router->delete('/api/schedule/{id}/skip', fn($params) => $scheduleController->unskip($params['id']), $requireAuth);
+$router->delete('/api/schedule/{id}', fn($params) => $scheduleController->cancel($params['id']), $requireWrite);
+$router->put('/api/schedule/{id}/target-temp', fn($params) => handleScheduleUpdateTargetTemp($scheduleController, $params['id']), $requireWrite);
+$router->post('/api/schedule/{id}/skip', fn($params) => $scheduleController->skip($params['id']), $requireWrite);
+$router->delete('/api/schedule/{id}/skip', fn($params) => $scheduleController->unskip($params['id']), $requireWrite);
 
 // Admin-only user management routes
 $router->get('/api/users', fn() => $userController->list(), $requireAdmin);
@@ -344,14 +345,24 @@ $router->get('/api/admin/crontab', fn() => [
 
 // Protected maintenance routes (called by cron with CRON_JWT)
 // Note: /api/cron/health bypasses framework via .htaccess -> cron-health.php
-$router->post('/api/maintenance/logs/rotate', fn() => $maintenanceController->rotateLogs(), $requireAuth);
-$router->post('/api/maintenance/jobs/cleanup', fn() => $maintenanceController->cleanupOrphanedJobs(), $requireAuth);
-$router->post('/api/maintenance/all', fn() => $maintenanceController->runAll(), $requireAuth);
-$router->post('/api/maintenance/heat-target-check', fn() => $targetTemperatureController->check(), $requireAuth);
-$router->post('/api/maintenance/dtdt-wakeup', fn() => handleDtdtWakeUp($dtdtService), $requireAuth);
+$router->post('/api/maintenance/logs/rotate', fn() => $maintenanceController->rotateLogs(), $requireWrite);
+$router->post('/api/maintenance/jobs/cleanup', fn() => $maintenanceController->cleanupOrphanedJobs(), $requireWrite);
+$router->post('/api/maintenance/all', fn() => $maintenanceController->runAll(), $requireWrite);
+$router->post('/api/maintenance/heat-target-check', fn() => $targetTemperatureController->check(), $requireWrite);
+$router->post('/api/maintenance/dtdt-wakeup', fn() => handleDtdtWakeUp($dtdtService), $requireWrite);
+
+// Global read-only enforcement (belt-and-suspenders to the per-route requireWrite
+// guard): a 'readonly' token may only issue safe (non-mutating) HTTP methods. This
+// also covers any future mutating route that forgets to use $requireWrite.
+$guardUser = $authMiddleware->authenticate($headers, $cookies);
+$readonlyBlocked = $guardUser !== null
+    && ($guardUser['role'] ?? '') === 'readonly'
+    && !in_array($method, ['GET', 'HEAD', 'OPTIONS'], true);
 
 // Dispatch request
-$response = $router->dispatch($method, $uri);
+$response = $readonlyBlocked
+    ? ['status' => 403, 'body' => ['error' => 'Read-only access: write operations are not permitted']]
+    : $router->dispatch($method, $uri);
 
 http_response_code($response['status']);
 echo json_encode($response['body']);

--- a/backend/src/Contracts/UserRepositoryInterface.php
+++ b/backend/src/Contracts/UserRepositoryInterface.php
@@ -38,6 +38,19 @@ interface UserRepositoryInterface
     public function create(string $username, string $password, string $role = 'user'): array;
 
     /**
+     * Create a system account with password login disabled.
+     *
+     * Used for non-human identities (cron runner, integrations) that
+     * authenticate with a minted token rather than a password.
+     *
+     * @param string $username Username (must be unique)
+     * @param string $role User role (e.g. 'admin', 'readonly')
+     * @return array Created user data
+     * @throws \InvalidArgumentException If username already exists
+     */
+    public function createSystemAccount(string $username, string $role = 'admin'): array;
+
+    /**
      * Delete a user.
      *
      * @param string $username Username to delete

--- a/backend/src/Middleware/AuthMiddleware.php
+++ b/backend/src/Middleware/AuthMiddleware.php
@@ -8,6 +8,13 @@ use HotTub\Services\AuthService;
 
 class AuthMiddleware
 {
+    /**
+     * Roles permitted to perform mutating (write) operations. Any other role
+     * (notably 'readonly') is denied write access. Layer-1 validation in
+     * AuthService guarantees this role matches the user's current DB role.
+     */
+    private const WRITE_ROLES = ['admin', 'user', 'basic'];
+
     public function __construct(
         private AuthService $authService
     ) {
@@ -62,6 +69,31 @@ class AuthMiddleware
                 'status' => 403,
                 'body' => [
                     'error' => 'Admin access required',
+                ],
+            ];
+        }
+
+        return null;
+    }
+
+    public function requireWrite(array $headers, array $cookies): ?array
+    {
+        $user = $this->authenticate($headers, $cookies);
+
+        if ($user === null) {
+            return [
+                'status' => 401,
+                'body' => [
+                    'error' => 'Authentication required',
+                ],
+            ];
+        }
+
+        if (!in_array($user['role'] ?? '', self::WRITE_ROLES, true)) {
+            return [
+                'status' => 403,
+                'body' => [
+                    'error' => 'Write access required',
                 ],
             ];
         }

--- a/backend/src/Services/AuthService.php
+++ b/backend/src/Services/AuthService.php
@@ -46,9 +46,26 @@ class AuthService
     {
         try {
             $decoded = JWT::decode($token, new Key($this->jwtSecret, 'HS256'));
-            return (array) $decoded;
+            $claims = (array) $decoded;
         } catch (\Exception $e) {
             throw new \RuntimeException('Invalid token: ' . $e->getMessage());
         }
+
+        // DB-backed validation: the token's subject must still resolve to a
+        // user, and its claimed role must match that user's current role. This
+        // makes the user store authoritative — deleting a user (or changing its
+        // role) immediately invalidates its outstanding tokens, even tokens the
+        // backend was never told were minted.
+        $user = $this->userRepository->findByUsername($claims['sub'] ?? '');
+
+        if ($user === null) {
+            throw new \RuntimeException('Invalid token: unknown subject');
+        }
+
+        if (($user['role'] ?? null) !== ($claims['role'] ?? null)) {
+            throw new \RuntimeException('Invalid token: role mismatch');
+        }
+
+        return $claims;
     }
 }

--- a/backend/src/Services/JsonUserRepository.php
+++ b/backend/src/Services/JsonUserRepository.php
@@ -14,7 +14,15 @@ use HotTub\Contracts\UserRepositoryInterface;
  */
 class JsonUserRepository implements UserRepositoryInterface
 {
-    private const VALID_ROLES = ['admin', 'user', 'basic'];
+    private const VALID_ROLES = ['admin', 'user', 'basic', 'readonly'];
+
+    /**
+     * Sentinel password hash for system accounts (cron, integrations) that
+     * authenticate via a minted token, never a password. It can never be
+     * produced by password_hash(), so verifyPassword() always rejects it.
+     */
+    private const LOCKED_PASSWORD_HASH = '*';
+
     private string $filePath;
 
     public function __construct(string $filePath)
@@ -57,6 +65,21 @@ class JsonUserRepository implements UserRepositoryInterface
 
     public function create(string $username, string $password, string $role = 'user'): array
     {
+        return $this->insert($username, password_hash($password, PASSWORD_BCRYPT), $role);
+    }
+
+    public function createSystemAccount(string $username, string $role = 'admin'): array
+    {
+        // System accounts authenticate via a minted token, so they get a locked
+        // password hash that no password can satisfy (login disabled).
+        return $this->insert($username, self::LOCKED_PASSWORD_HASH, $role);
+    }
+
+    /**
+     * Insert a new user with an already-prepared password hash.
+     */
+    private function insert(string $username, string $passwordHash, string $role): array
+    {
         $data = $this->load();
 
         if (isset($data['users'][$username])) {
@@ -70,7 +93,7 @@ class JsonUserRepository implements UserRepositoryInterface
 
         $createdAt = date('c');
         $data['users'][$username] = [
-            'password_hash' => password_hash($password, PASSWORD_BCRYPT),
+            'password_hash' => $passwordHash,
             'role' => $role,
             'created_at' => $createdAt,
         ];
@@ -116,7 +139,14 @@ class JsonUserRepository implements UserRepositoryInterface
             return false;
         }
 
-        return password_verify($password, $user['password_hash']);
+        // Locked/system accounts have a sentinel hash that is not a real hash;
+        // reject without calling password_verify (which would just return false).
+        $hash = $user['password_hash'];
+        if (!is_string($hash) || !str_starts_with($hash, '$')) {
+            return false;
+        }
+
+        return password_verify($password, $hash);
     }
 
     /**

--- a/backend/src/Services/UserRepositoryFactory.php
+++ b/backend/src/Services/UserRepositoryFactory.php
@@ -14,6 +14,13 @@ use HotTub\Contracts\UserRepositoryInterface;
  */
 class UserRepositoryFactory
 {
+    /**
+     * Username of the cron runner's identity. The cron JWT is minted with
+     * sub=cron-system / role=admin (see bin/generate-cron-jwt.php); DB-backed
+     * token validation requires this subject to exist as a user.
+     */
+    private const CRON_SYSTEM_USERNAME = 'cron-system';
+
     private string $filePath;
     private array $config;
 
@@ -38,7 +45,23 @@ class UserRepositoryFactory
             $this->bootstrap($repo);
         }
 
+        // Self-heal required system accounts on every boot (idempotent).
+        // This guarantees the cron identity exists once DB-backed token
+        // validation is active, with no manual provisioning step on deploy.
+        $this->ensureSystemAccounts($repo);
+
         return $repo;
+    }
+
+    /**
+     * Ensure non-human system accounts exist. Idempotent: only creates what's
+     * missing. System accounts have password login disabled.
+     */
+    private function ensureSystemAccounts(JsonUserRepository $repo): void
+    {
+        if ($repo->findByUsername(self::CRON_SYSTEM_USERNAME) === null) {
+            $repo->createSystemAccount(self::CRON_SYSTEM_USERNAME, 'admin');
+        }
     }
 
     /**

--- a/backend/tests/Bin/MintJwtTest.php
+++ b/backend/tests/Bin/MintJwtTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Tests\Bin;
+
+use PHPUnit\Framework\TestCase;
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+
+/**
+ * Tests for the mint-jwt.php script's core logic.
+ */
+class MintJwtTest extends TestCase
+{
+    private string $jwtSecret = 'test-secret-for-phpunit-only';
+
+    private function loadScript(): void
+    {
+        require_once dirname(__DIR__, 2) . '/bin/mint-jwt.php';
+    }
+
+    public function testMintedTokenDecodesToRequestedSubjectAndRole(): void
+    {
+        $this->loadScript();
+
+        $token = mintJwt($this->jwtSecret, 'homeassistant', 'readonly', 10);
+        $decoded = JWT::decode($token, new Key($this->jwtSecret, 'HS256'));
+
+        $this->assertEquals('homeassistant', $decoded->sub);
+        $this->assertEquals('readonly', $decoded->role);
+    }
+
+    public function testMintedTokenHasRequestedExpiry(): void
+    {
+        $this->loadScript();
+
+        $token = mintJwt($this->jwtSecret, 'homeassistant', 'readonly', 10);
+        $decoded = JWT::decode($token, new Key($this->jwtSecret, 'HS256'));
+
+        $nineYears = time() + (9 * 365 * 24 * 60 * 60);
+        $elevenYears = time() + (11 * 365 * 24 * 60 * 60);
+        $this->assertGreaterThan($nineYears, $decoded->exp);
+        $this->assertLessThan($elevenYears, $decoded->exp);
+    }
+
+    public function testReadJwtSecretFailsWhenFileMissing(): void
+    {
+        $this->loadScript();
+
+        $result = readJwtSecret('/nonexistent/path/.env');
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('not found', strtolower($result['message']));
+    }
+
+    public function testReadJwtSecretExtractsSecret(): void
+    {
+        $this->loadScript();
+
+        $envFile = sys_get_temp_dir() . '/mint-jwt-test-' . uniqid() . '.env';
+        file_put_contents($envFile, "JWT_SECRET={$this->jwtSecret}\nOTHER=1\n");
+
+        $result = readJwtSecret($envFile);
+
+        $this->assertTrue($result['success']);
+        $this->assertEquals($this->jwtSecret, $result['secret']);
+
+        unlink($envFile);
+    }
+}

--- a/backend/tests/Middleware/AuthMiddlewareTest.php
+++ b/backend/tests/Middleware/AuthMiddlewareTest.php
@@ -176,6 +176,54 @@ class AuthMiddlewareTest extends TestCase
         $this->assertEquals('Admin access required', $response['body']['error']);
     }
 
+    // --- requireWrite (Layer 2a) ---
+
+    public function testRequireWriteReturns401WhenNotAuthenticated(): void
+    {
+        $response = $this->middleware->requireWrite([], []);
+
+        $this->assertNotNull($response);
+        $this->assertEquals(401, $response['status']);
+        $this->assertEquals('Authentication required', $response['body']['error']);
+    }
+
+    public function testRequireWriteReturnsNullForAdminUser(): void
+    {
+        $token = TestAuthHelper::getValidToken(); // admin
+        $headers = ['Authorization' => 'Bearer ' . $token];
+
+        $this->assertNull($this->middleware->requireWrite($headers, []));
+    }
+
+    public function testRequireWriteReturnsNullForBasicUser(): void
+    {
+        $userRepo = TestAuthHelper::getUserRepository();
+        if ($userRepo->findByUsername('writebasic') === null) {
+            $userRepo->create('writebasic', 'password', 'basic');
+        }
+        $token = TestAuthHelper::getAuthService()->login('writebasic', 'password');
+        $headers = ['Authorization' => 'Bearer ' . $token];
+
+        // basic is a write role (e.g. vickie controls hardware) — must pass.
+        $this->assertNull($this->middleware->requireWrite($headers, []));
+    }
+
+    public function testRequireWriteReturns403ForReadonlyUser(): void
+    {
+        $userRepo = TestAuthHelper::getUserRepository();
+        if ($userRepo->findByUsername('readonlyuser') === null) {
+            $userRepo->create('readonlyuser', 'password', 'readonly');
+        }
+        $token = TestAuthHelper::getAuthService()->login('readonlyuser', 'password');
+        $headers = ['Authorization' => 'Bearer ' . $token];
+
+        $response = $this->middleware->requireWrite($headers, []);
+
+        $this->assertNotNull($response);
+        $this->assertEquals(403, $response['status']);
+        $this->assertEquals('Write access required', $response['body']['error']);
+    }
+
     public function testBasicUserTokenHasCorrectRole(): void
     {
         // Create a basic user and verify the token contains the correct role

--- a/backend/tests/PreProduction/DtdtReadyByE2ETest.php
+++ b/backend/tests/PreProduction/DtdtReadyByE2ETest.php
@@ -131,7 +131,9 @@ class DtdtReadyByE2ETest extends TestCase
         $payload = $this->base64UrlEncode(json_encode([
             'iat' => time(),
             'exp' => time() + 3600,
-            'sub' => 'e2e-test-user',
+            // DB-backed validation requires sub to resolve to a real user; the
+            // server self-provisions 'cron-system' (admin) on boot.
+            'sub' => 'cron-system',
             'role' => 'admin',
         ]));
         $signature = $this->base64UrlEncode(hash_hmac('sha256', "$header.$payload", $secret, true));

--- a/backend/tests/PreProduction/HeatToTargetE2ETest.php
+++ b/backend/tests/PreProduction/HeatToTargetE2ETest.php
@@ -101,7 +101,9 @@ class HeatToTargetE2ETest extends TestCase
         $payload = $this->base64UrlEncode(json_encode([
             'iat' => time(),
             'exp' => time() + 3600,
-            'sub' => 'e2e-test',
+            // DB-backed validation requires sub to resolve to a real user; the
+            // server self-provisions 'cron-system' (admin) on boot.
+            'sub' => 'cron-system',
             'role' => 'admin',
         ]));
         $signature = $this->base64UrlEncode(hash_hmac('sha256', "$header.$payload", $secret, true));

--- a/backend/tests/PreProduction/HeatToTargetRealPathsE2ETest.php
+++ b/backend/tests/PreProduction/HeatToTargetRealPathsE2ETest.php
@@ -117,7 +117,9 @@ class HeatToTargetRealPathsE2ETest extends TestCase
         $payload = $this->base64UrlEncode(json_encode([
             'iat' => time(),
             'exp' => time() + 3600,
-            'sub' => 'e2e-test-user',
+            // DB-backed validation requires sub to resolve to a real user; the
+            // server self-provisions 'cron-system' (admin) on boot.
+            'sub' => 'cron-system',
             'role' => 'admin',
         ]));
         $signature = $this->base64UrlEncode(hash_hmac('sha256', "$header.$payload", $secret, true));

--- a/backend/tests/Services/AuthServiceTest.php
+++ b/backend/tests/Services/AuthServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace HotTub\Tests\Services;
 
 use PHPUnit\Framework\TestCase;
+use Firebase\JWT\JWT;
 use HotTub\Services\AuthService;
 use HotTub\Contracts\UserRepositoryInterface;
 
@@ -183,5 +184,68 @@ class AuthServiceTest extends TestCase
 
         $this->assertEquals('boss', $claims['sub']);
         $this->assertEquals('admin', $claims['role']);
+    }
+
+    // --- Layer 1: DB-backed token validation ---
+
+    private function mintToken(string $sub, string $role): string
+    {
+        return JWT::encode([
+            'iat' => time(),
+            'exp' => time() + 3600,
+            'sub' => $sub,
+            'role' => $role,
+        ], $this->config['JWT_SECRET'], 'HS256');
+    }
+
+    public function testValidateTokenRejectsUnknownSubject(): void
+    {
+        // Subject does not resolve to any user (e.g. its account was deleted, or
+        // the token was minted out-of-band for a never-provisioned identity).
+        $mock = $this->createMock(UserRepositoryInterface::class);
+        $mock->method('findByUsername')->willReturn(null);
+        $authService = new AuthService($mock, $this->config);
+
+        $token = $this->mintToken('ghost', 'admin');
+
+        $this->expectException(\RuntimeException::class);
+        $authService->validateToken($token);
+    }
+
+    public function testValidateTokenRejectsRoleMismatch(): void
+    {
+        // Token claims 'basic' but the DB user is 'readonly' → reject. This is the
+        // auto-revoke guarantee: changing a user's role invalidates its old tokens.
+        $mock = $this->createMock(UserRepositoryInterface::class);
+        $mock->method('findByUsername')->willReturn([
+            'username' => 'homeassistant',
+            'role' => 'readonly',
+            'password_hash' => '*',
+            'created_at' => date('c'),
+        ]);
+        $authService = new AuthService($mock, $this->config);
+
+        $token = $this->mintToken('homeassistant', 'basic');
+
+        $this->expectException(\RuntimeException::class);
+        $authService->validateToken($token);
+    }
+
+    public function testValidateTokenAcceptsMatchingSubjectAndRole(): void
+    {
+        $mock = $this->createMock(UserRepositoryInterface::class);
+        $mock->method('findByUsername')->willReturn([
+            'username' => 'homeassistant',
+            'role' => 'readonly',
+            'password_hash' => '*',
+            'created_at' => date('c'),
+        ]);
+        $authService = new AuthService($mock, $this->config);
+
+        $token = $this->mintToken('homeassistant', 'readonly');
+        $claims = $authService->validateToken($token);
+
+        $this->assertSame('homeassistant', $claims['sub']);
+        $this->assertSame('readonly', $claims['role']);
     }
 }

--- a/backend/tests/Unit/Services/JsonUserRepositoryTest.php
+++ b/backend/tests/Unit/Services/JsonUserRepositoryTest.php
@@ -271,4 +271,29 @@ class JsonUserRepositoryTest extends TestCase
         $found = $repo->findByUsername('basic_user');
         $this->assertEquals('basic', $found['role']);
     }
+
+    public function testReadonlyRoleIsAccepted(): void
+    {
+        $repo = new JsonUserRepository($this->usersFile);
+
+        $readonlyUser = $repo->create('ha', 'pass', 'readonly');
+
+        $this->assertEquals('readonly', $readonlyUser['role']);
+        $this->assertEquals('readonly', $repo->findByUsername('ha')['role']);
+    }
+
+    public function testCreateSystemAccountDisablesPasswordLogin(): void
+    {
+        $repo = new JsonUserRepository($this->usersFile);
+
+        $account = $repo->createSystemAccount('cron-system', 'admin');
+
+        $this->assertEquals('admin', $account['role']);
+        // The account exists and has its role...
+        $this->assertEquals('admin', $repo->findByUsername('cron-system')['role']);
+        // ...but no password can authenticate it (login disabled).
+        $this->assertFalse($repo->verifyPassword('cron-system', ''));
+        $this->assertFalse($repo->verifyPassword('cron-system', 'admin'));
+        $this->assertFalse($repo->verifyPassword('cron-system', 'password'));
+    }
 }

--- a/backend/tests/Unit/Services/UserRepositoryFactoryTest.php
+++ b/backend/tests/Unit/Services/UserRepositoryFactoryTest.php
@@ -120,6 +120,48 @@ class UserRepositoryFactoryTest extends TestCase
         $factory->create();
     }
 
+    public function testProvisionsCronSystemAccountOnBootstrap(): void
+    {
+        $config = [
+            'AUTH_ADMIN_USERNAME' => 'admin',
+            'AUTH_ADMIN_PASSWORD' => 'password',
+        ];
+
+        $factory = new UserRepositoryFactory($this->usersFile, $config);
+        $repo = $factory->create();
+
+        // The cron identity must exist as an admin user (DB-backed validation needs it)...
+        $cron = $repo->findByUsername('cron-system');
+        $this->assertNotNull($cron);
+        $this->assertEquals('admin', $cron['role']);
+        // ...with password login disabled.
+        $this->assertFalse($repo->verifyPassword('cron-system', 'password'));
+    }
+
+    public function testSelfHealsCronSystemAccountWhenFileExistsWithoutIt(): void
+    {
+        // Existing users.json from before DB-backed validation: no cron-system row.
+        $existingData = [
+            'version' => 1,
+            'users' => [
+                'admin' => [
+                    'password_hash' => password_hash('existingpass', PASSWORD_BCRYPT),
+                    'role' => 'admin',
+                    'created_at' => date('c'),
+                ],
+            ],
+        ];
+        file_put_contents($this->usersFile, json_encode($existingData, JSON_PRETTY_PRINT));
+
+        $factory = new UserRepositoryFactory($this->usersFile, []);
+        $repo = $factory->create();
+
+        // cron-system should be added on boot even though the file already existed.
+        $this->assertNotNull($repo->findByUsername('cron-system'));
+        // Existing admin is untouched.
+        $this->assertTrue($repo->verifyPassword('admin', 'existingpass'));
+    }
+
     public function testDoesNotThrowForMissingCredentialsWhenFileExists(): void
     {
         // Pre-create the file

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -35,6 +35,10 @@
 	// Check if user has basic role (simplified UI)
 	const isBasicUser = $derived(data.user?.role === 'basic');
 
+	// Read-only users (e.g. Home Assistant) can view data but not control hardware.
+	// The backend enforces this; hiding the controls keeps the UI honest.
+	const isReadOnly = $derived(data.user?.role === 'readonly');
+
 	// Reactive equipment status
 	let heaterOn = $derived(getHeaterOn());
 	let pumpOn = $derived(getPumpOn());
@@ -180,7 +184,8 @@
 	</header>
 
 	<main class="flex-1 flex flex-col gap-3 max-w-md mx-auto w-full">
-		<!-- Compact Primary Controls -->
+		<!-- Compact Primary Controls (hidden for read-only users) -->
+		{#if !isReadOnly}
 		<div class="grid grid-cols-3 gap-2">
 			<CompactControlButton
 				label={getHeatButtonLabel()}
@@ -207,6 +212,7 @@
 				onClick={() => handleAction(api.pumpRun, 'Pump running for 2 hours', setPumpOn)}
 			/>
 		</div>
+		{/if}
 
 		<!-- ETA: Estimated time to reach target temperature -->
 		{#if etaDisplay}
@@ -224,7 +230,7 @@
 		{/if}
 
 		<!-- Dining Room Blinds Controls (optional feature, half-height) -->
-		{#if blindsEnabled}
+		{#if blindsEnabled && !isReadOnly}
 			<div class="grid grid-cols-2 gap-2">
 				<CompactControlButton
 					label="Blinds Up"
@@ -272,21 +278,21 @@
 			</div>
 		{/if}
 
-		<!-- Quick Schedule Buttons (hidden for basic users) -->
-		{#if !isBasicUser}
+		<!-- Quick Schedule Buttons (hidden for basic and read-only users) -->
+		{#if !isBasicUser && !isReadOnly}
 			<QuickSchedulePanel onScheduled={handleQuickScheduled} />
 		{/if}
 
 		<!-- Temperature Display -->
 		<TemperaturePanel bind:this={temperaturePanel} />
 
-		<!-- Full Schedule Panel (hidden for basic users) -->
-		{#if !isBasicUser}
+		<!-- Full Schedule Panel (hidden for basic and read-only users) -->
+		{#if !isBasicUser && !isReadOnly}
 			<SchedulePanel bind:this={schedulePanel} onHeaterOffCompleted={handleHeaterOffCompleted} />
 		{/if}
 
-		<!-- Settings Panel (hidden for basic users) -->
-		{#if !isBasicUser}
+		<!-- Settings Panel (hidden for basic and read-only users) -->
+		{#if !isBasicUser && !isReadOnly}
 			<SettingsPanel isAdmin={data.user?.role === 'admin'} />
 		{/if}
 

--- a/frontend/src/routes/users/+page.svelte
+++ b/frontend/src/routes/users/+page.svelte
@@ -13,7 +13,7 @@
 	// Form state
 	let newUsername = $state('');
 	let newPassword = $state('');
-	let newRole = $state<'user' | 'admin' | 'basic'>('user');
+	let newRole = $state<'user' | 'admin' | 'basic' | 'readonly'>('user');
 	let isCreating = $state(false);
 
 	// Credential display modal
@@ -192,6 +192,7 @@
 							bind:value={newRole}
 							class="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded text-slate-100 focus:outline-none focus:border-cyan-500"
 						>
+							<option value="readonly">Read-only (view only, e.g. Home Assistant)</option>
 							<option value="basic">Basic (simplified UI)</option>
 							<option value="user">User</option>
 							<option value="admin">Admin</option>
@@ -248,7 +249,7 @@
 							<li class="flex items-center justify-between bg-slate-700/50 rounded p-3">
 								<div>
 									<span class="text-slate-100 font-medium">{user.username}</span>
-									<span class="ml-2 px-2 py-0.5 text-xs rounded {user.role === 'admin' ? 'bg-amber-500/20 text-amber-400' : user.role === 'basic' ? 'bg-cyan-500/20 text-cyan-400' : 'bg-slate-600 text-slate-300'}">
+									<span class="ml-2 px-2 py-0.5 text-xs rounded {user.role === 'admin' ? 'bg-amber-500/20 text-amber-400' : user.role === 'basic' ? 'bg-cyan-500/20 text-cyan-400' : user.role === 'readonly' ? 'bg-violet-500/20 text-violet-400' : 'bg-slate-600 text-slate-300'}">
 										{user.role}
 									</span>
 								</div>


### PR DESCRIPTION
Deploys DB-backed JWT validation and a new `readonly` role so the Home Assistant integration can run on a read-only token.

**Behavior changes on production after deploy:**
- Token validation now requires the `sub` to be an existing user and the claimed role to match the stored role. Existing sessions for admin/user/vickie keep working (their roles match). The cron identity `cron-system` self-heals as a login-disabled admin user on first boot, so cron keeps working with no manual step.
- A token whose subject is not a provisioned user is now rejected (401). This will invalidate the current Home Assistant token if it uses a dedicated, unprovisioned subject — it is being replaced as part of this rollout.
- New `readonly` role: blocked from all mutating routes (403) by `requireWrite` and a global non-GET guard.

Tests: backend 945 pass, frontend 198 pass, e2e 123 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)