### PR TITLE
Cut webapp backend over to iot-api (device-path surface)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,8 @@ jobs:
           EXTERNAL_API_MODE=live
           API_BASE_URL=${{ vars.API_BASE_URL }}
           IFTTT_WEBHOOK_KEY=${{ secrets.IFTTT_WEBHOOK_KEY }}
+          IOT_API_URL=${{ secrets.IOT_API_URL }}
+          IOT_API_JWT=${{ secrets.IOT_API_JWT }}
           AUTH_ADMIN_USERNAME=${{ secrets.AUTH_ADMIN_USERNAME }}
           AUTH_ADMIN_PASSWORD=${{ secrets.AUTH_ADMIN_PASSWORD }}
           JWT_SECRET=${{ secrets.JWT_SECRET }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,9 @@ ESP32_API_KEY=your-api-key
   - `TargetTemperatureService` - Heat-to-target feature with automatic cron-based temperature checks, ETA computation
   - `HeatTargetSettingsService` - Stores global heat-to-target enabled/target_temp/dynamic mode settings
   - `DynamicTargetCalculator` - Piecewise linear interpolation for ambient-adjusted water target temperatures
-  - `AuthService` - JWT token validation
+  - `AuthService` - JWT issuance + **DB-backed token validation** (subject must exist as a user and claimed role must match the stored role — see Authentication & Roles)
+  - `AuthMiddleware` - Authorization guards: `requireAuth` / `requireAdmin` / `requireWrite`
+  - `JsonUserRepository` / `UserRepositoryFactory` - User store; factory self-heals system accounts (`cron-system`) on boot
   - `EquipmentStatusService` - Tracks heater/pump on/off state in JSON file
   - `RequestLogger` - API request logging in JSON Lines format
   - `LogRotationService` - Compresses and deletes old log files
@@ -191,6 +193,37 @@ ESP32_API_KEY=your-api-key
   - `NullHealthchecksClient` - No-op client (stub mode or no API key)
 - **Factory**: `HealthchecksClientFactory` - Creates client based on EXTERNAL_API_MODE
 
+### Authentication & Roles
+
+**DB-backed token validation.** JWTs are validated against the user store, not just the
+signature. `AuthService::validateToken()` requires the token's `sub` to resolve to an
+existing user **and** the claimed `role` to equal that user's current stored role —
+otherwise 401. Consequences:
+- **Revoke a token by deleting/renaming its user or changing its role.** The user store is
+  the source of truth; there is no separate denylist. This also rejects tokens that were
+  minted out-of-band for a subject the backend was never told about.
+- Mint a long-lived token with `php backend/bin/mint-jwt.php --sub <name> --role <role> --years <n>`.
+  The subject must already exist as a user with that role, or the token is rejected.
+
+**Roles** (`JsonUserRepository::VALID_ROLES`): `admin`, `user`, `basic`, `readonly`.
+- `admin` — full access including user management and global settings.
+- `user` — full hardware/scheduling control, but no admin-only endpoints.
+- `basic` — **a write role**: simplified UI, but can still control hardware. NOT read-only.
+- `readonly` — read (GET) only; blocked from every mutation. Used by integrations like
+  Home Assistant.
+
+**Authorization guards** (`AuthMiddleware`): `requireAuth` (any valid token), `requireAdmin`
+(role `admin`), and `requireWrite` (role ∈ admin/user/basic — `readonly` → 403) on every
+mutating route. A global guard in `index.php` additionally 403s any non-GET request from a
+`readonly` token (defense-in-depth).
+
+**System accounts.** Non-human identities (the cron runner uses `sub=cron-system`,
+`role=admin`) are real user rows with password login disabled (`createSystemAccount` stores
+a sentinel hash). `UserRepositoryFactory` self-heals `cron-system` on every boot, so
+deploying DB-backed validation never breaks cron and needs no manual provisioning. Revoke a
+system identity by rotating its token (e.g. `bin/generate-cron-jwt.php`), not by deleting
+the self-healing row.
+
 ### Frontend
 - **Framework**: SvelteKit with Svelte 5 runes (`$state`, `$effect`)
 - **Styling**: Tailwind CSS v4
@@ -210,26 +243,30 @@ ESP32_API_KEY=your-api-key
   - `SensorConfigPanel.svelte` - ESP32 sensor role/calibration configuration (admin only)
 
 ### API Endpoints
-- `GET /api/health` - Health check with equipment status and heat-target settings
+
+Auth levels (see Authentication & Roles): **public** (none) · **auth** (any valid token) ·
+**write** (admin/user/basic — `readonly` is blocked) · **admin** (admin only).
+
+- `GET /api/health` - Health check with equipment status and heat-target settings (public)
 - `POST /api/auth/login` - Login (sets httpOnly cookie)
 - `POST /api/auth/logout` - Logout (clears cookie)
 - `GET /api/auth/me` - Get current user info
-- `POST /api/equipment/heater/on` - Trigger IFTTT `hot-tub-heat-on` (auth required)
-- `POST /api/equipment/heater/off` - Trigger IFTTT `hot-tub-heat-off` (auth required)
-- `POST /api/equipment/pump/run` - Trigger IFTTT `cycle_hot_tub_ionizer` (auth required)
-- `GET /api/temperature` - Get current temperatures from ESP32
+- `POST /api/equipment/heater/on` - Trigger IFTTT `hot-tub-heat-on` (write)
+- `POST /api/equipment/heater/off` - Trigger IFTTT `hot-tub-heat-off` (write)
+- `POST /api/equipment/pump/run` - Trigger IFTTT `cycle_hot_tub_ionizer` (write)
+- `GET /api/temperature` - Get current temperatures from ESP32 (auth)
 - `POST /api/esp32/temperature` - Receive temperature data from ESP32 (API key auth)
-- `GET /api/esp32/sensors` - List ESP32 sensors with config (admin only)
-- `PUT /api/esp32/sensors/{address}` - Update sensor role/calibration (admin only)
-- `GET /api/settings/heat-target` - Get heat-to-target settings (auth required)
+- `GET /api/esp32/sensors` - List ESP32 sensors with config (auth)
+- `PUT /api/esp32/sensors/{address}` - Update sensor role/calibration (write)
+- `GET /api/settings/heat-target` - Get heat-to-target settings (auth)
 - `PUT /api/settings/heat-target` - Update heat-to-target settings (admin only)
-- `POST /api/schedule` - Schedule a future action (auth required)
-- `GET /api/schedule` - List scheduled jobs (auth required)
-- `DELETE /api/schedule/{id}` - Cancel scheduled job (auth required)
+- `POST /api/schedule` - Schedule a future action (write)
+- `GET /api/schedule` - List scheduled jobs (auth)
+- `DELETE /api/schedule/{id}` - Cancel scheduled job (write)
 - `GET /api/users` - List users (admin only)
-- `POST /api/users` - Create user (admin only)
-- `DELETE /api/users/{username}` - Delete user (admin only)
-- `POST /api/maintenance/logs/rotate` - Rotate log files (cron auth)
+- `POST /api/users` - Create user, optionally `role: readonly` (admin only)
+- `DELETE /api/users/{username}` - Delete user; also revokes that user's tokens (admin only)
+- `POST /api/maintenance/logs/rotate` - Rotate log files (write; called by cron as `cron-system`)
 
 ## DRY Principles
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ The system uses IFTTT webhooks to control SmartLife/Tuya smart relays, making it
 
 ### Users & Authentication
 - **JWT Authentication** - Secure login with httpOnly cookie support
-- **Three User Roles** - Admin (full access), User (controls + scheduling), Basic (controls + temperature only)
+- **DB-backed token validation** - A token is valid only if its subject is an existing user and its claimed role matches the stored role. Deleting a user (or changing its role) immediately revokes that user's tokens — there is no separate denylist.
+- **Four User Roles** - Admin (full access), User (controls + scheduling), Basic (controls + simplified UI), Readonly (view only — for integrations like Home Assistant; blocked from all writes)
 - **User Management** - Admin interface for creating, managing, and deleting users
 - **Password Management** - Admin can reset user passwords
+- **Token minting** - `backend/bin/mint-jwt.php --sub <name> --role <role> --years <n>` issues a long-lived token for a provisioned user (e.g. a read-only Home Assistant integration)
 
 ### Monitoring & Maintenance
 - **Healthchecks.io Integration** - Optional monitoring for cron job alerts

--- a/backend/config/env.production.example
+++ b/backend/config/env.production.example
@@ -36,3 +36,11 @@ API_BASE_URL=https://your-server.com/path/to/backend/public
 # Optional Features
 # Dining room blinds control (set to 'true' to enable)
 BLINDS_FEATURE_ENABLED=true
+
+# iot-api relay (IFTTT deprecation cutover — see
+# ~/dev/home-assistant/docs/plans/ifttt-deprecation-iot-api.md).
+# Required only when the DI wiring is swapped from IftttClient to
+# IotApiClient in live mode. JWT minted with sub=hottub-webapp in
+# the iot-api repo (bin/mint-jwt.php).
+# IOT_API_URL=https://misuse.org/iot/public/api/v1/command
+# IOT_API_JWT=<jwt for sub=hottub-webapp>

--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -27,7 +27,7 @@ use HotTub\Services\EnvLoader;
 use HotTub\Services\CookieHelper;
 use HotTub\Services\EquipmentStatusService;
 use HotTub\Services\HeaterControlService;
-use HotTub\Services\IftttClientFactory;
+use HotTub\Services\IotApiClientFactory;
 use HotTub\Services\AuthService;
 use HotTub\Services\UserRepositoryFactory;
 use HotTub\Services\SchedulerService;
@@ -57,6 +57,8 @@ if (file_exists($envPath)) {
         'APP_ENV' => $_ENV['APP_ENV'] ?? getenv('APP_ENV') ?: 'development',
         'IFTTT_MODE' => $_ENV['IFTTT_MODE'] ?? getenv('IFTTT_MODE') ?: 'auto',
         'IFTTT_WEBHOOK_KEY' => $_ENV['IFTTT_WEBHOOK_KEY'] ?? getenv('IFTTT_WEBHOOK_KEY') ?: null,
+        'IOT_API_URL' => $_ENV['IOT_API_URL'] ?? getenv('IOT_API_URL') ?: null,
+        'IOT_API_JWT' => $_ENV['IOT_API_JWT'] ?? getenv('IOT_API_JWT') ?: null,
     ];
 }
 
@@ -93,8 +95,11 @@ $authController = new AuthController($authService);
 $cookieHelper = new CookieHelper(CookieHelper::deriveAppBasePath());
 $userController = new UserController($userRepository);
 
-// Create IFTTT client via factory (uses EXTERNAL_API_MODE from config)
-$factory = new IftttClientFactory($config, $logFile);
+// Create the device-command client via factory (uses EXTERNAL_API_MODE from
+// config). 2026-07 cutover: IotApiClient (misuse.org/iot -> HA) replaced
+// IftttClient behind the same IftttClientInterface — consumers unchanged.
+// Rollback = swap IotApiClientFactory back to IftttClientFactory here.
+$factory = new IotApiClientFactory($config, $logFile);
 $iftttClient = $factory->create();
 
 // Create equipment status service for tracking heater/pump state

--- a/backend/src/Contracts/JsonHttpClientInterface.php
+++ b/backend/src/Contracts/JsonHttpClientInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Contracts;
+
+/**
+ * HTTP client for JSON POST requests with custom headers.
+ *
+ * Companion to HttpClientInterface (which is body-less and header-less,
+ * shaped for IFTTT's key-in-URL webhooks). iot-api needs a JSON body and
+ * an Authorization header, so this is a separate additive contract rather
+ * than a breaking change to the existing one.
+ */
+interface JsonHttpClientInterface
+{
+    /**
+     * POST a JSON body.
+     *
+     * @param string $url The URL to POST to
+     * @param array<string, mixed> $body JSON-encodable request body
+     * @param array<int, string> $headers Extra headers ("Name: value" strings)
+     * @return HttpResponse The response (status 0 on transport failure)
+     */
+    public function postJson(string $url, array $body, array $headers = []): HttpResponse;
+}

--- a/backend/src/Services/CurlJsonHttpClient.php
+++ b/backend/src/Services/CurlJsonHttpClient.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Services;
+
+use HotTub\Contracts\HttpResponse;
+use HotTub\Contracts\JsonHttpClientInterface;
+
+/**
+ * Live JSON HTTP client (cURL).
+ *
+ * Unlike CurlHttpClient this never follows redirects: requests carry an
+ * Authorization header and must not be replayed to a redirect target.
+ */
+class CurlJsonHttpClient implements JsonHttpClientInterface
+{
+    public function __construct(private int $timeout = 15)
+    {
+    }
+
+    public function postJson(string $url, array $body, array $headers = []): HttpResponse
+    {
+        $curl = curl_init();
+
+        curl_setopt_array($curl, [
+            CURLOPT_URL => $url,
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => json_encode($body, JSON_THROW_ON_ERROR),
+            CURLOPT_TIMEOUT => $this->timeout,
+            CURLOPT_USERAGENT => 'HotTubController/2.0',
+            CURLOPT_HTTPHEADER => array_merge(
+                ['Content-Type: application/json', 'Accept: application/json'],
+                $headers
+            ),
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
+        ]);
+
+        $responseBody = curl_exec($curl);
+        $httpCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        $error = curl_error($curl);
+
+        curl_close($curl);
+
+        if ($responseBody === false || !empty($error)) {
+            return new HttpResponse(0, $error ?: 'Unknown cURL error');
+        }
+
+        return new HttpResponse($httpCode, (string) $responseBody);
+    }
+}

--- a/backend/src/Services/IotApiClient.php
+++ b/backend/src/Services/IotApiClient.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Services;
+
+use HotTub\Contracts\IftttClientInterface;
+use HotTub\Contracts\JsonHttpClientInterface;
+
+/**
+ * iot-api adapter for the IFTTT-deprecation cutover.
+ *
+ * Implements IftttClientInterface so HeaterControlService and
+ * BlindsController swap over with a one-line DI change and zero consumer
+ * edits: legacy IFTTT event names are translated to iot-api command
+ * bodies ({device, action}) and POSTed to
+ * https://misuse.org/iot/public/api/v1/command, which relays to Home
+ * Assistant over the Tailscale Funnel. See
+ * ~/dev/home-assistant/docs/plans/ifttt-deprecation-iot-api.md.
+ *
+ * Same late-binding strategy as IftttClient: business logic is identical
+ * in stub and live modes; only the injected JSON HTTP client differs.
+ */
+class IotApiClient implements IftttClientInterface
+{
+    /**
+     * Legacy IFTTT event name -> iot-api command body.
+     *
+     * Only events this backend actually triggers are mapped (the webapp's
+     * five call sites). Devices "hot-tub-heater", "hot-tub-cycle-ionizer"
+     * and "dining-blinds" require the HA-side iot_internal Phase-1
+     * generalization before live cutover — until then HA answers 404
+     * unknown_device, which trigger() reports as failure.
+     */
+    private const EVENT_MAP = [
+        'hot-tub-heat-on' => ['device' => 'hot-tub-heater', 'action' => 'turn_on'],
+        'hot-tub-heat-off' => ['device' => 'hot-tub-heater', 'action' => 'turn_off'],
+        'cycle_hot_tub_ionizer' => ['device' => 'hot-tub-cycle-ionizer', 'action' => 'run'],
+        'open-dining-room-blinds' => ['device' => 'dining-blinds', 'action' => 'open'],
+        'close-dining-room-blinds' => ['device' => 'dining-blinds', 'action' => 'close'],
+    ];
+
+    private string $mode;
+
+    public function __construct(
+        private string $apiUrl,
+        private string $apiJwt,
+        private JsonHttpClientInterface $httpClient,
+        private ConsoleLogger $console,
+        private EventLogger $logger
+    ) {
+        $this->mode = $httpClient instanceof StubJsonHttpClient ? 'stub' : 'live';
+    }
+
+    public function trigger(string $eventName): bool
+    {
+        $body = self::EVENT_MAP[$eventName] ?? null;
+        if ($body === null) {
+            $this->logger->log('iot_api_unknown_event', ['event' => $eventName]);
+            return false;
+        }
+
+        $start = microtime(true);
+        $response = $this->httpClient->postJson(
+            $this->apiUrl,
+            $body,
+            ['Authorization: Bearer ' . $this->apiJwt]
+        );
+        $durationMs = (int) round((microtime(true) - $start) * 1000);
+
+        $httpCode = $response->getStatusCode();
+        $success = $response->isSuccess();
+
+        if ($this->mode === 'stub') {
+            $this->console->stub($eventName, $durationMs);
+        } else {
+            $this->console->live($eventName, $httpCode, $durationMs);
+        }
+
+        $data = [
+            'event' => $eventName,
+            'device' => $body['device'],
+            'action' => $body['action'],
+            'http_code' => $httpCode,
+            'duration_ms' => $durationMs,
+            'success' => $success,
+        ];
+        if ($this->mode === 'stub') {
+            $data['simulated'] = true;
+        }
+        $this->logger->log($this->mode === 'stub' ? 'iot_api_stub' : 'iot_api_live', $data);
+
+        return $success;
+    }
+
+    public function getMode(): string
+    {
+        return $this->mode;
+    }
+}

--- a/backend/src/Services/IotApiClient.php
+++ b/backend/src/Services/IotApiClient.php
@@ -12,10 +12,10 @@ use HotTub\Contracts\JsonHttpClientInterface;
  *
  * Implements IftttClientInterface so HeaterControlService and
  * BlindsController swap over with a one-line DI change and zero consumer
- * edits: legacy IFTTT event names are translated to iot-api command
- * bodies ({device, action}) and POSTed to
- * https://misuse.org/iot/public/api/v1/command, which relays to Home
- * Assistant over the Tailscale Funnel. See
+ * edits: legacy IFTTT event names are translated to the iot-api REST
+ * device-path surface (2026-07 normalization) and POSTed to
+ * {base}/api/v1/device/{slug}, which relays to Home Assistant over the
+ * Tailscale Funnel. See
  * ~/dev/home-assistant/docs/plans/ifttt-deprecation-iot-api.md.
  *
  * Same late-binding strategy as IftttClient: business logic is identical
@@ -24,45 +24,48 @@ use HotTub\Contracts\JsonHttpClientInterface;
 class IotApiClient implements IftttClientInterface
 {
     /**
-     * Legacy IFTTT event name -> iot-api command body.
+     * Legacy IFTTT event name -> [device slug, request body].
      *
      * Only events this backend actually triggers are mapped (the webapp's
-     * five call sites). Devices "hot-tub-heater", "hot-tub-cycle-ionizer"
-     * and "dining-blinds" require the HA-side iot_internal Phase-1
-     * generalization before live cutover — until then HA answers 404
-     * unknown_device, which trigger() reports as failure.
+     * five call sites). The heater events use the unified partial-update
+     * "set" action (implicit when the body has no action): power on/off
+     * dispatches script.hot_tub_heater_on/_off HA-side via the script
+     * suffix convention.
      */
     private const EVENT_MAP = [
-        'hot-tub-heat-on' => ['device' => 'hot-tub-heater', 'action' => 'turn_on'],
-        'hot-tub-heat-off' => ['device' => 'hot-tub-heater', 'action' => 'turn_off'],
-        'cycle_hot_tub_ionizer' => ['device' => 'hot-tub-cycle-ionizer', 'action' => 'run'],
-        'open-dining-room-blinds' => ['device' => 'dining-blinds', 'action' => 'open'],
-        'close-dining-room-blinds' => ['device' => 'dining-blinds', 'action' => 'close'],
+        'hot-tub-heat-on' => ['hot-tub-heater', ['power' => 'on']],
+        'hot-tub-heat-off' => ['hot-tub-heater', ['power' => 'off']],
+        'cycle_hot_tub_ionizer' => ['hot-tub-cycle-ionizer', ['action' => 'run']],
+        'open-dining-room-blinds' => ['dining-blinds', ['action' => 'open']],
+        'close-dining-room-blinds' => ['dining-blinds', ['action' => 'close']],
     ];
 
     private string $mode;
+    private string $apiBase;
 
     public function __construct(
-        private string $apiUrl,
+        string $apiBaseUrl,
         private string $apiJwt,
         private JsonHttpClientInterface $httpClient,
         private ConsoleLogger $console,
         private EventLogger $logger
     ) {
+        $this->apiBase = rtrim($apiBaseUrl, '/');
         $this->mode = $httpClient instanceof StubJsonHttpClient ? 'stub' : 'live';
     }
 
     public function trigger(string $eventName): bool
     {
-        $body = self::EVENT_MAP[$eventName] ?? null;
-        if ($body === null) {
+        $mapped = self::EVENT_MAP[$eventName] ?? null;
+        if ($mapped === null) {
             $this->logger->log('iot_api_unknown_event', ['event' => $eventName]);
             return false;
         }
+        [$device, $body] = $mapped;
 
         $start = microtime(true);
         $response = $this->httpClient->postJson(
-            $this->apiUrl,
+            $this->apiBase . '/api/v1/device/' . $device,
             $body,
             ['Authorization: Bearer ' . $this->apiJwt]
         );
@@ -79,8 +82,8 @@ class IotApiClient implements IftttClientInterface
 
         $data = [
             'event' => $eventName,
-            'device' => $body['device'],
-            'action' => $body['action'],
+            'device' => $device,
+            'body' => $body,
             'http_code' => $httpCode,
             'duration_ms' => $durationMs,
             'success' => $success,

--- a/backend/src/Services/IotApiClientFactory.php
+++ b/backend/src/Services/IotApiClientFactory.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Services;
+
+use HotTub\Contracts\IftttClientInterface;
+use InvalidArgumentException;
+use RuntimeException;
+
+/**
+ * Factory for iot-api clients. Mirrors IftttClientFactory: mode resolution
+ * priority is EXTERNAL_API_MODE env var, then config, then fail-safe stub.
+ * Config keys: IOT_API_URL, IOT_API_JWT.
+ */
+class IotApiClientFactory
+{
+    /** @var array<string, string|null> */
+    private array $config;
+    private string $logFile;
+    /** @var resource */
+    private $output;
+
+    /**
+     * @param array<string, string|null> $config Environment configuration
+     * @param string $logFile Path to event log file
+     * @param resource|null $output Console output stream
+     */
+    public function __construct(array $config, string $logFile, $output = null)
+    {
+        $this->config = $config;
+        $this->logFile = $logFile;
+        $this->output = $output ?? fopen('php://stderr', 'w');
+    }
+
+    public function create(string $mode = 'auto'): IftttClientInterface
+    {
+        $resolvedMode = match ($mode) {
+            'stub' => 'stub',
+            'live' => 'live',
+            'auto' => $this->resolveAutoMode(),
+            default => throw new InvalidArgumentException("Invalid mode: {$mode}"),
+        };
+
+        if ($resolvedMode === 'live') {
+            $url = trim((string) ($this->config['IOT_API_URL'] ?? ''));
+            $jwt = trim((string) ($this->config['IOT_API_JWT'] ?? ''));
+            if ($url === '' || $jwt === '') {
+                throw new RuntimeException('IOT_API_URL and IOT_API_JWT required for live mode');
+            }
+            $httpClient = new CurlJsonHttpClient();
+        } else {
+            $url = trim((string) ($this->config['IOT_API_URL'] ?? '')) ?: 'https://stub.invalid/api/v1/command';
+            $jwt = 'stub-mode-no-jwt';
+            $httpClient = new StubJsonHttpClient();
+        }
+
+        $client = new IotApiClient(
+            $url,
+            $jwt,
+            $httpClient,
+            new ConsoleLogger($this->output),
+            new EventLogger($this->logFile)
+        );
+
+        $this->getConsoleLogger()->init($client->getMode());
+
+        return $client;
+    }
+
+    private function resolveAutoMode(): string
+    {
+        $envMode = getenv('EXTERNAL_API_MODE') ?: ($_ENV['EXTERNAL_API_MODE'] ?? null);
+        if ($envMode !== null && $envMode !== '' && in_array($envMode, ['stub', 'live'], true)) {
+            return $envMode;
+        }
+
+        $externalApiMode = $this->config['EXTERNAL_API_MODE'] ?? null;
+        if ($externalApiMode !== null && in_array($externalApiMode, ['stub', 'live'], true)) {
+            return $externalApiMode;
+        }
+
+        return 'stub';
+    }
+
+    private function getConsoleLogger(): ConsoleLogger
+    {
+        return new ConsoleLogger($this->output);
+    }
+}

--- a/backend/src/Services/IotApiClientFactory.php
+++ b/backend/src/Services/IotApiClientFactory.php
@@ -11,7 +11,8 @@ use RuntimeException;
 /**
  * Factory for iot-api clients. Mirrors IftttClientFactory: mode resolution
  * priority is EXTERNAL_API_MODE env var, then config, then fail-safe stub.
- * Config keys: IOT_API_URL, IOT_API_JWT.
+ * Config keys: IOT_API_URL (the base, e.g. https://misuse.org/iot — the
+ * client appends /api/v1/device/{slug}), IOT_API_JWT.
  */
 class IotApiClientFactory
 {
@@ -50,7 +51,7 @@ class IotApiClientFactory
             }
             $httpClient = new CurlJsonHttpClient();
         } else {
-            $url = trim((string) ($this->config['IOT_API_URL'] ?? '')) ?: 'https://stub.invalid/api/v1/command';
+            $url = trim((string) ($this->config['IOT_API_URL'] ?? '')) ?: 'https://stub.invalid';
             $jwt = 'stub-mode-no-jwt';
             $httpClient = new StubJsonHttpClient();
         }

--- a/backend/src/Services/StubJsonHttpClient.php
+++ b/backend/src/Services/StubJsonHttpClient.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Services;
+
+use HotTub\Contracts\HttpResponse;
+use HotTub\Contracts\JsonHttpClientInterface;
+use RuntimeException;
+
+/**
+ * Stub JSON HTTP client — same tripwire convention as StubHttpClient:
+ * instantiation while EXTERNAL_API_MODE=live is a configuration bug.
+ *
+ * Records the last request so tests can assert URL/body/headers, and
+ * returns a canned iot-api-shaped shadowed response.
+ */
+class StubJsonHttpClient implements JsonHttpClientInterface
+{
+    private const SIMULATED_DELAY_MS = 50;
+
+    public ?string $lastUrl = null;
+
+    /** @var array<string, mixed>|null */
+    public ?array $lastBody = null;
+
+    /** @var array<int, string>|null */
+    public ?array $lastHeaders = null;
+
+    private ?HttpResponse $cannedResponse = null;
+
+    public function __construct()
+    {
+        $apiMode = getenv('EXTERNAL_API_MODE') ?: ($_ENV['EXTERNAL_API_MODE'] ?? 'auto');
+        if ($apiMode === 'live') {
+            throw new RuntimeException(
+                'StubJsonHttpClient instantiated while EXTERNAL_API_MODE=live. ' .
+                'This indicates a configuration bug - the factory should have created a live client.'
+            );
+        }
+    }
+
+    public function setResponse(HttpResponse $response): void
+    {
+        $this->cannedResponse = $response;
+    }
+
+    public function postJson(string $url, array $body, array $headers = []): HttpResponse
+    {
+        usleep(self::SIMULATED_DELAY_MS * 1000);
+
+        $this->lastUrl = $url;
+        $this->lastBody = $body;
+        $this->lastHeaders = $headers;
+
+        if ($this->cannedResponse !== null) {
+            return $this->cannedResponse;
+        }
+
+        return new HttpResponse(200, json_encode([
+            'ok' => true,
+            'device' => $body['device'] ?? null,
+            'action' => $body['action'] ?? null,
+            'shadowed' => true,
+            'reason' => 'stub_mode',
+            'stub' => true,
+        ], JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/backend/tests/Unit/Services/IotApiClientFactoryTest.php
+++ b/backend/tests/Unit/Services/IotApiClientFactoryTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Tests\Unit\Services;
+
+use PHPUnit\Framework\TestCase;
+use HotTub\Services\IotApiClientFactory;
+use InvalidArgumentException;
+use RuntimeException;
+
+class IotApiClientFactoryTest extends TestCase
+{
+    private string $testLogFile;
+
+    protected function setUp(): void
+    {
+        $this->testLogFile = sys_get_temp_dir() . '/iot-api-factory-test-' . uniqid() . '.log';
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->testLogFile)) {
+            unlink($this->testLogFile);
+        }
+    }
+
+    private function makeFactory(array $config): IotApiClientFactory
+    {
+        return new IotApiClientFactory($config, $this->testLogFile, fopen('php://memory', 'w+'));
+    }
+
+    public function testExplicitStubMode(): void
+    {
+        $client = $this->makeFactory([])->create('stub');
+        $this->assertSame('stub', $client->getMode());
+    }
+
+    public function testAutoModeDefaultsToStub(): void
+    {
+        // phpunit.xml forces EXTERNAL_API_MODE=stub; with no config either,
+        // fail-safe default is stub.
+        $client = $this->makeFactory([])->create('auto');
+        $this->assertSame('stub', $client->getMode());
+    }
+
+    public function testLiveModeRequiresUrlAndJwt(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->makeFactory(['IOT_API_URL' => 'https://misuse.org/iot'])->create('live');
+    }
+
+    public function testInvalidModeThrows(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->makeFactory([])->create('production');
+    }
+}

--- a/backend/tests/Unit/Services/IotApiClientTest.php
+++ b/backend/tests/Unit/Services/IotApiClientTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HotTub\Tests\Unit\Services;
+
+use PHPUnit\Framework\TestCase;
+use HotTub\Contracts\HttpResponse;
+use HotTub\Contracts\IftttClientInterface;
+use HotTub\Services\ConsoleLogger;
+use HotTub\Services\EventLogger;
+use HotTub\Services\IotApiClient;
+use HotTub\Services\StubJsonHttpClient;
+
+/**
+ * Tests for the iot-api adapter that replaces IftttClient at the
+ * IFTTT-deprecation cutover. Verifies interface compatibility, the
+ * event -> {device, action} translation, auth header injection, and
+ * failure reporting.
+ */
+class IotApiClientTest extends TestCase
+{
+    private const API_URL = 'https://misuse.org/iot/public/api/v1/command';
+
+    private string $testLogFile;
+    private StubJsonHttpClient $httpClient;
+
+    protected function setUp(): void
+    {
+        $this->testLogFile = sys_get_temp_dir() . '/iot-api-client-test-' . uniqid() . '.log';
+        $this->httpClient = new StubJsonHttpClient();
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->testLogFile)) {
+            unlink($this->testLogFile);
+        }
+    }
+
+    private function makeClient(): IotApiClient
+    {
+        $output = fopen('php://memory', 'w+');
+
+        return new IotApiClient(
+            self::API_URL,
+            'test-jwt-token',
+            $this->httpClient,
+            new ConsoleLogger($output),
+            new EventLogger($this->testLogFile)
+        );
+    }
+
+    public function testImplementsIftttClientInterface(): void
+    {
+        // The whole point of the adapter: consumers keep their
+        // IftttClientInterface dependency, only DI wiring changes.
+        $this->assertInstanceOf(IftttClientInterface::class, $this->makeClient());
+    }
+
+    public function testModeIsStubWithStubHttpClient(): void
+    {
+        $this->assertSame('stub', $this->makeClient()->getMode());
+    }
+
+    /**
+     * @dataProvider eventTranslationProvider
+     */
+    public function testTranslatesEventsToCommandBodies(string $event, array $expectedBody): void
+    {
+        $result = $this->makeClient()->trigger($event);
+
+        $this->assertTrue($result);
+        $this->assertSame(self::API_URL, $this->httpClient->lastUrl);
+        $this->assertSame($expectedBody, $this->httpClient->lastBody);
+    }
+
+    public static function eventTranslationProvider(): array
+    {
+        return [
+            'heat on' => ['hot-tub-heat-on', ['device' => 'hot-tub-heater', 'action' => 'turn_on']],
+            'heat off' => ['hot-tub-heat-off', ['device' => 'hot-tub-heater', 'action' => 'turn_off']],
+            'cycle ionizer' => ['cycle_hot_tub_ionizer', ['device' => 'hot-tub-cycle-ionizer', 'action' => 'run']],
+            'blinds open' => ['open-dining-room-blinds', ['device' => 'dining-blinds', 'action' => 'open']],
+            'blinds close' => ['close-dining-room-blinds', ['device' => 'dining-blinds', 'action' => 'close']],
+        ];
+    }
+
+    public function testSendsBearerAuthorizationHeader(): void
+    {
+        $this->makeClient()->trigger('hot-tub-heat-on');
+
+        $this->assertContains(
+            'Authorization: Bearer test-jwt-token',
+            $this->httpClient->lastHeaders
+        );
+    }
+
+    public function testUnknownEventReturnsFalseWithoutHttpCall(): void
+    {
+        $result = $this->makeClient()->trigger('no-such-event');
+
+        $this->assertFalse($result);
+        $this->assertNull($this->httpClient->lastUrl);
+
+        $log = file_get_contents($this->testLogFile);
+        $this->assertStringContainsString('iot_api_unknown_event', $log);
+    }
+
+    public function testUpstreamErrorStatusReturnsFalse(): void
+    {
+        // HA 404 unknown_device passed through by iot-api.
+        $this->httpClient->setResponse(new HttpResponse(404, '{"message":"no such device"}'));
+
+        $this->assertFalse($this->makeClient()->trigger('hot-tub-heat-on'));
+    }
+
+    public function testTransportFailureReturnsFalse(): void
+    {
+        $this->httpClient->setResponse(new HttpResponse(0, 'connection timed out'));
+
+        $this->assertFalse($this->makeClient()->trigger('hot-tub-heat-on'));
+    }
+
+    public function testLogsAuditTrail(): void
+    {
+        $this->makeClient()->trigger('hot-tub-heat-on');
+
+        $log = file_get_contents($this->testLogFile);
+        $this->assertStringContainsString('iot_api_stub', $log);
+        $this->assertStringContainsString('hot-tub-heater', $log);
+        $this->assertStringContainsString('"simulated":true', $log);
+    }
+}

--- a/backend/tests/Unit/Services/IotApiClientTest.php
+++ b/backend/tests/Unit/Services/IotApiClientTest.php
@@ -15,12 +15,13 @@ use HotTub\Services\StubJsonHttpClient;
 /**
  * Tests for the iot-api adapter that replaces IftttClient at the
  * IFTTT-deprecation cutover. Verifies interface compatibility, the
- * event -> {device, action} translation, auth header injection, and
- * failure reporting.
+ * event -> device-path + body translation (the 2026-07 REST surface:
+ * POST {base}/api/v1/device/{slug} with orthogonal params), auth header
+ * injection, and failure reporting.
  */
 class IotApiClientTest extends TestCase
 {
-    private const API_URL = 'https://misuse.org/iot/public/api/v1/command';
+    private const API_BASE = 'https://misuse.org/iot';
 
     private string $testLogFile;
     private StubJsonHttpClient $httpClient;
@@ -38,12 +39,12 @@ class IotApiClientTest extends TestCase
         }
     }
 
-    private function makeClient(): IotApiClient
+    private function makeClient(string $base = self::API_BASE): IotApiClient
     {
         $output = fopen('php://memory', 'w+');
 
         return new IotApiClient(
-            self::API_URL,
+            $base,
             'test-jwt-token',
             $this->httpClient,
             new ConsoleLogger($output),
@@ -66,24 +67,36 @@ class IotApiClientTest extends TestCase
     /**
      * @dataProvider eventTranslationProvider
      */
-    public function testTranslatesEventsToCommandBodies(string $event, array $expectedBody): void
+    public function testTranslatesEventsToDevicePathCalls(string $event, string $expectedUrl, array $expectedBody): void
     {
         $result = $this->makeClient()->trigger($event);
 
         $this->assertTrue($result);
-        $this->assertSame(self::API_URL, $this->httpClient->lastUrl);
+        $this->assertSame($expectedUrl, $this->httpClient->lastUrl);
         $this->assertSame($expectedBody, $this->httpClient->lastBody);
     }
 
     public static function eventTranslationProvider(): array
     {
+        $device = self::API_BASE . '/api/v1/device/';
+
         return [
-            'heat on' => ['hot-tub-heat-on', ['device' => 'hot-tub-heater', 'action' => 'turn_on']],
-            'heat off' => ['hot-tub-heat-off', ['device' => 'hot-tub-heater', 'action' => 'turn_off']],
-            'cycle ionizer' => ['cycle_hot_tub_ionizer', ['device' => 'hot-tub-cycle-ionizer', 'action' => 'run']],
-            'blinds open' => ['open-dining-room-blinds', ['device' => 'dining-blinds', 'action' => 'open']],
-            'blinds close' => ['close-dining-room-blinds', ['device' => 'dining-blinds', 'action' => 'close']],
+            'heat on' => ['hot-tub-heat-on', $device . 'hot-tub-heater', ['power' => 'on']],
+            'heat off' => ['hot-tub-heat-off', $device . 'hot-tub-heater', ['power' => 'off']],
+            'cycle ionizer' => ['cycle_hot_tub_ionizer', $device . 'hot-tub-cycle-ionizer', ['action' => 'run']],
+            'blinds open' => ['open-dining-room-blinds', $device . 'dining-blinds', ['action' => 'open']],
+            'blinds close' => ['close-dining-room-blinds', $device . 'dining-blinds', ['action' => 'close']],
         ];
+    }
+
+    public function testTrailingSlashOnBaseUrlIsNormalized(): void
+    {
+        $this->makeClient(self::API_BASE . '/')->trigger('hot-tub-heat-on');
+
+        $this->assertSame(
+            self::API_BASE . '/api/v1/device/hot-tub-heater',
+            $this->httpClient->lastUrl
+        );
     }
 
     public function testSendsBearerAuthorizationHeader(): void


### PR DESCRIPTION
Phase 3 of the IFTTT swapout (see ~/dev/home-assistant plan): the webapp backend now relays device commands through iot-api (misuse.org/iot → Tailscale Funnel → HA) instead of IFTTT maker webhooks.

- IotApiClient targets the normalized REST surface: `POST {IOT_API_URL}/api/v1/device/{slug}`. Heater events use the unified `set` action (`{"power":"on"/"off"}`); ionizer/blinds keep explicit `run`/`open`/`close`.
- DI swap in `backend/public/index.php`: `IotApiClientFactory` replaces `IftttClientFactory` behind the unchanged `IftttClientInterface`. Rollback = swap the factory back. IftttClient stays in-tree until Phase 5 teardown.
- `deploy.yml` ships `IOT_API_URL`/`IOT_API_JWT` (GH secrets already set).

Safety: all four HA-side gates (`live_iot_hot_tub_heater/_cycle_ionizer/_ionizer`, `live_iot_dining_blinds`) are OFF — every webapp trigger relays but is **shadowed** until the supervised gate flip. PHPUnit 962 green on this base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)