### PR TITLE
v2 schedule: unify card steppers + fix 0.25°F temp step

### DIFF
--- a/docs/redesign/v2-interface.md
+++ b/docs/redesign/v2-interface.md
@@ -147,9 +147,10 @@ automatically." QuickSchedule is gone.
 Each stage is TDD red/green per `CLAUDE.md`; tests run **only** via `./scripts/test.sh`. The
 old UI stays live until Stage 5.
 
-> **Status (2026-07-08):** Stages 0–2 are ✅ done (with deliberate deviations noted
-> below). Stage 2.5 (card parity) is the active work. Stages 3–5 remain. A UX review of
-> the shipped stages lives in `v2-ux-review.md`; open decisions in `v2-open-questions.md`.
+> **Status (2026-07-09):** Stages 0–2.5 are ✅ done (with deliberate deviations noted
+> below), including the F8 control-paradigm unification. Stage 3 decomposition and
+> Stages 4–5 remain. A UX review of the shipped stages lives in `v2-ux-review.md`; open
+> decisions in `v2-open-questions.md`.
 
 ### Stage 0 — Branch + scaffold ✅
 - Create `feature/v2-interface`; commit this doc.
@@ -186,7 +187,7 @@ old UI stays live until Stage 5.
 - **Verify gate:** User creates one-off + recurring jobs; Guest has no Schedule tab; tests
   green. ✅
 
-### Stage 2.5 — Card parity (recurring ⇄ one-off) ✅ (except F8)
+### Stage 2.5 — Card parity (recurring ⇄ one-off) ✅ (complete, incl. F8)
 - Backend (TDD): atomic **in-place recurring reschedule** — change a recurring job's daily
   time (+ optional temp) preserving its id, mirroring `rescheduleOneOff`. Must rewrite the
   daily cron via `CronSchedulingService`/`scheduleDailyInTimezone`, keep the healthcheck
@@ -197,9 +198,17 @@ old UI stays live until Stage 5.
   Save/Discard for recurring heat-to-target as for one-offs (recurring differs only by the
   repeat indicator + Skip next). "Edit temp" input retires.
 - Also fold Home's adjust-bar into the selected card (review F8) so Home and Schedule share
-  one expanded-card interaction. ← **remaining piece; do with Steve's eyes on the mockup**
+  one expanded-card interaction. ✅ Shipped 2026-07-09, per Steve's call: went further than
+  the tap-to-expand sketch — every card shows its controls (no selection state at all).
+  Home renders `EventCard` per folded event; `next-controls`, the radio-card selection, and
+  the switch-guard modal are deleted. Both pages fold via `foldScheduledEvents`. Recurring
+  Save semantics stay per-page via callback choice (`onOverrideNext` on Home = just the next
+  run; `onRescheduleRecurring` on Schedule = the daily default), and an adjusted card offers
+  **Reset to daily** + **Make permanent** (promote the override into the daily default, then
+  clear it — composed client-side in `lib/scheduleActions.ts`, reschedule before clear so a
+  partial failure never loses the adjustment). Home cards gained Remove (full parity).
 - **Verify gate:** recurring daily time/temp edit round-trips; skip/override flows intact;
-  tests green. ✅ (backend + Schedule tab landed 2026-07-08; F8 open)
+  tests green. ✅ (backend + Schedule tab landed 2026-07-08; F8 landed 2026-07-09)
 
 ### Stage 3 — Setup (Owner) — shell ✅, decomposition pending
 > Shipped as a shell first (2026-07-08): `v2/setup` gates on `canConfigure`, re-homes

--- a/docs/redesign/v2-ux-review.md
+++ b/docs/redesign/v2-ux-review.md
@@ -75,7 +75,7 @@ now Owner/User; Guests see the target inside the Heat button label and can still
 it. Backend still permits `basic` writes to that endpoint — flagged as a question (UI-only
 gate vs. tightening the endpoint).
 
-### F8. Home's adjust bar floats above the thing it edits — [proposal]
+### F8. Home's adjust bar floats above the thing it edits — [fixed 2026-07-09]
 The "Adjusting just the next run" control bar sits *above* the card list and acts on the
 selected card *below* it. The bar reads as its own card; the target of the ± steppers is
 spatially inverted, and selection ("radio-card") is an unusual pattern to discover.
@@ -98,9 +98,13 @@ NEXT UP                                 NEXT UP
 │ Thu, Jul 9 3:00 PM       │             expands, controls move)
 └──────────────────────────┘
 ```
-Not implemented tonight: it touches the selection/guard state machine and E2E specs;
-better done deliberately as part of the Stage-2.5 card-parity work, where Home's expanded
-card and Schedule's card become the same component.
+Landed 2026-07-09, going further than the sketch on Steve's call: instead of tap-to-expand,
+every Home card shows its controls (the Schedule tab's paradigm, verbatim) — the control
+bar, radio-card selection, and switch-guard modal are deleted outright. Home and Schedule
+now both render `EventCard` over `foldScheduledEvents`. Save on Home still overrides just
+the next run; an adjusted card offers **Reset to daily** and a new **Make permanent**
+(promotes the override into the daily default — `lib/scheduleActions.ts`). Home cards also
+gained Remove (full parity).
 
 ### F9. Recurring vs one-off cards still lack parity — [fixed later the same night]
 On the Schedule tab a one-off got inline ± time/temp steppers; a recurring card got a
@@ -126,4 +130,7 @@ next shows while clean). "Edit temp" is retired from adjustable cards.
   plain `heater-on` mode has no v2 auto-off. [question]
 - **DRY**: `formatTemp`/`formatClock`/`resumeLabel`/repeat-icon/`ACTION_LABELS` are
   duplicated between Home and EventCard — fold into `scheduleUtils`/a shared snippet
-  during the parity refactor.
+  during the parity refactor. [done 2026-07-09 — helpers live in `scheduleUtils.ts`
+  (`formatTemp`, `shiftHHMM`, `formatClockHHMM`, `jobTitle`, `resumeLabel`, `jobClock`,
+  `baseSummary`, `oneOffIso`); Home no longer has its own copies, and the repeat icon
+  renders only inside `EventCard`]

--- a/frontend/e2e/v2-home.spec.ts
+++ b/frontend/e2e/v2-home.spec.ts
@@ -70,7 +70,9 @@ test.describe('v2 Home (MVP)', () => {
 			await page.reload();
 			const nextUp = page.getByTestId('v2-next-up');
 			await expect(nextUp).toBeVisible({ timeout: 15000 });
-			await expect(nextUp.getByTestId('next-card-title')).toHaveText(/Heat to 101\.5/);
+			await expect(nextUp.getByTestId('event-title')).toHaveText(/Heat to 101\.5/);
+			// One paradigm everywhere: no floating control bar — the card carries its controls.
+			await expect(page.getByTestId('next-controls')).toHaveCount(0);
 		});
 	});
 
@@ -82,11 +84,10 @@ test.describe('v2 Home (MVP)', () => {
 			}
 		});
 
-		test('nudging stages the next run; Save overrides it as one folded card; reset returns to the daily default', async ({
-			page
-		}) => {
-			// Clear leftovers, then create a daily event whose time has already passed today
-			// (so the skip + override land tomorrow and are always in the future).
+		// Clear leftovers, then create a daily event whose time has already passed today
+		// (so the skip + override land tomorrow and are always in the future). Returns
+		// the parent job id and its daily HH:MM.
+		async function createDaily(page: import('@playwright/test').Page) {
 			const list = await (await page.request.get('/tub/backend/public/api/schedule')).json();
 			for (const j of list.jobs ?? []) {
 				await page.request.delete(`/tub/backend/public/api/schedule/${j.jobId}`);
@@ -104,30 +105,81 @@ test.describe('v2 Home (MVP)', () => {
 				}
 			});
 			expect(res.ok()).toBeTruthy();
+			const jobId = (await res.json()).jobId as string;
+			const plus15 = new Date(past.getTime() + 15 * 60 * 1000);
+			const hhmmPlus15 = `${String(plus15.getHours()).padStart(2, '0')}:${String(plus15.getMinutes()).padStart(2, '0')}`;
+			return { jobId, hhmm, hhmmPlus15 };
+		}
+
+		test('nudging the card stages the next run; Save overrides it as one folded card; reset returns to the daily default', async ({
+			page
+		}) => {
+			await createDaily(page);
 
 			await page.reload();
-			// The control bar auto-selects the only adjustable event — no manual select needed.
-			const controls = page.getByTestId('next-controls');
-			await expect(controls).toBeVisible({ timeout: 15000 });
-			await expect(page.getByTestId('next-card')).toHaveCount(1);
-			await expect(page.getByTestId('next-reset')).toHaveCount(0); // not yet overridden
+			const nextUp = page.getByTestId('v2-next-up');
+			await expect(nextUp).toBeVisible({ timeout: 15000 });
+			// One paradigm: the card carries its own controls — no floating control bar,
+			// no selection step.
+			await expect(page.getByTestId('next-controls')).toHaveCount(0);
+			const card = nextUp.getByTestId('event-card');
+			await expect(card).toHaveCount(1);
+			await expect(card.getByTestId('event-reset')).toHaveCount(0); // not yet overridden
 
 			// Nudge 15 minutes later → staged locally only; nothing persists until Save.
-			await controls.getByRole('button', { name: '15 minutes later' }).click();
-			await expect(page.getByTestId('next-save')).toBeVisible({ timeout: 10000 });
-			await expect(page.getByTestId('next-card-adjusted')).toHaveCount(0); // not committed yet
+			await card.getByRole('button', { name: '15 minutes later' }).click();
+			await expect(card.getByTestId('event-oneoff-save')).toBeVisible({ timeout: 10000 });
+			await expect(card.getByTestId('event-adjusted')).toHaveCount(0); // not committed yet
 
 			// Save → the override is created, folded into the SAME one card.
-			await page.getByTestId('next-save').click();
-			await expect(page.getByTestId('next-reset')).toBeVisible({ timeout: 10000 });
-			await expect(page.getByTestId('next-card-adjusted')).toBeVisible();
+			await card.getByTestId('event-oneoff-save').click();
+			await expect(card.getByTestId('event-reset')).toBeVisible({ timeout: 10000 });
+			await expect(card.getByTestId('event-adjusted')).toBeVisible();
+			await expect(card.getByTestId('event-resets-line')).toBeVisible();
 			// Regression: the override does NOT split the daily into a second card.
-			await expect(page.getByTestId('next-card')).toHaveCount(1);
+			await expect(nextUp.getByTestId('event-card')).toHaveCount(1);
 
 			// Reset → back to the daily default (no override, still one card).
-			await page.getByTestId('next-reset').click();
-			await expect(page.getByTestId('next-reset')).toHaveCount(0, { timeout: 10000 });
-			await expect(page.getByTestId('next-card')).toHaveCount(1);
+			await card.getByTestId('event-reset').click();
+			await expect(card.getByTestId('event-reset')).toHaveCount(0, { timeout: 10000 });
+			await expect(nextUp.getByTestId('event-card')).toHaveCount(1);
+		});
+
+		test('Make permanent promotes the override into the daily default and clears it', async ({
+			page
+		}) => {
+			const { jobId, hhmmPlus15 } = await createDaily(page);
+
+			await page.reload();
+			const nextUp = page.getByTestId('v2-next-up');
+			await expect(nextUp).toBeVisible({ timeout: 15000 });
+			const card = nextUp.getByTestId('event-card');
+			await expect(card).toHaveCount(1);
+
+			// Create the override through the card: nudge +15 → Save.
+			await card.getByRole('button', { name: '15 minutes later' }).click();
+			await card.getByTestId('event-oneoff-save').click();
+			await expect(card.getByTestId('event-make-permanent')).toBeVisible({ timeout: 10000 });
+
+			// Promote → the adjusted state clears; still ONE card.
+			await card.getByTestId('event-make-permanent').click();
+			await expect(card.getByTestId('event-adjusted')).toHaveCount(0, { timeout: 10000 });
+			await expect(card.getByTestId('event-make-permanent')).toHaveCount(0);
+			await expect(nextUp.getByTestId('event-card')).toHaveCount(1);
+
+			// Backend truth: the parent's daily time moved to the override's clock, and no
+			// override one-off survives.
+			const jobs = (await (await page.request.get('/tub/backend/public/api/schedule')).json())
+				.jobs as Array<{
+				jobId: string;
+				scheduledTime: string;
+				skipped?: boolean;
+				params?: { override_of?: string };
+			}>;
+			const parent = jobs.find((j) => j.jobId === jobId);
+			expect(parent?.scheduledTime).toBe(hhmmPlus15);
+			expect(parent?.skipped).toBeFalsy();
+			expect(jobs.some((j) => j.params?.override_of)).toBe(false);
 		});
 	});
 
@@ -139,7 +191,7 @@ test.describe('v2 Home (MVP)', () => {
 			}
 		});
 
-		test('a one-off heat event is adjustable on Home: nudging stages, Save moves it in place', async ({
+		test('a one-off heat event is adjustable on Home: nudging stages, Save moves it in place, Remove deletes it', async ({
 			page
 		}) => {
 			// Clear leftovers, then create a one-off heat-to-target tomorrow at a unique temp so we
@@ -162,16 +214,13 @@ test.describe('v2 Home (MVP)', () => {
 			const jobId = (await res.json()).jobId;
 
 			await page.reload();
-			// Select our one-off by its stable key (the only event present after the clear).
-			const card = page.locator(`[data-testid="next-card"][data-key="${jobId}"]`);
+			// The card carries its own controls — no selection step, no floating bar.
+			const card = page.locator(`[data-testid="event-card"][data-key="${jobId}"]`);
 			await expect(card).toBeVisible({ timeout: 15000 });
-			await card.click();
-
-			const controls = page.getByTestId('next-controls');
-			await expect(controls).toBeVisible();
+			await expect(page.getByTestId('next-controls')).toHaveCount(0);
 			// A one-off offers ±, but NOT the recurring-only Skip, and never the "edit on the
 			// Schedule tab" redirect (the bug this test pins down).
-			await expect(page.getByTestId('next-skip')).toHaveCount(0);
+			await expect(card.getByTestId('event-skip')).toHaveCount(0);
 			await expect(page.getByText('edit it on the Schedule tab')).toHaveCount(0);
 
 			const tempOf = async () => {
@@ -181,16 +230,21 @@ test.describe('v2 Home (MVP)', () => {
 			};
 
 			// Nudge temp + time → staged locally; the backend is untouched until Save.
-			await controls.getByRole('button', { name: 'half a degree warmer' }).click();
-			await controls.getByRole('button', { name: '15 minutes later' }).click();
-			await expect(page.getByTestId('next-save')).toBeVisible();
+			await card.getByRole('button', { name: 'a quarter degree warmer' }).click();
+			await card.getByRole('button', { name: '15 minutes later' }).click();
+			await expect(card.getByTestId('event-oneoff-save')).toBeVisible();
 			expect(await tempOf()).toBe(108.25);
 
-			// Save → moved in place: SAME job id (not recreated), backend now 108.75.
-			await page.getByTestId('next-save').click();
-			await expect(page.getByTestId('next-save')).toHaveCount(0, { timeout: 10000 });
-			await expect(page.locator(`[data-testid="next-card"][data-key="${jobId}"]`)).toBeVisible();
-			expect(await tempOf()).toBe(108.75);
+			// Save → moved in place: SAME job id (not recreated), backend now 108.50.
+			await card.getByTestId('event-oneoff-save').click();
+			await expect(card.getByTestId('event-oneoff-save')).toHaveCount(0, { timeout: 10000 });
+			await expect(card).toBeVisible();
+			expect(await tempOf()).toBe(108.50);
+
+			// Full parity: Remove works from Home too.
+			await card.getByTestId('event-cancel').click();
+			await expect(card).toHaveCount(0, { timeout: 10000 });
+			expect(await tempOf()).toBeUndefined();
 		});
 	});
 
@@ -219,10 +273,10 @@ test.describe('v2 Home (MVP)', () => {
 			await expect(page.getByTestId('target-value')).toHaveText('103°F');
 			await expect(page.getByRole('button', { name: 'Heat to 103°F' })).toBeVisible();
 
-			// Raise by one step (+0.5°F): label updates immediately.
+			// Raise by one step (+0.25°F): label updates immediately.
 			await dial.getByRole('button', { name: 'Raise target temperature' }).click();
-			await expect(page.getByTestId('target-value')).toHaveText('103.5°F');
-			await expect(page.getByRole('button', { name: 'Heat to 103.5°F' })).toBeVisible();
+			await expect(page.getByTestId('target-value')).toHaveText('103.25°F');
+			await expect(page.getByRole('button', { name: 'Heat to 103.25°F' })).toBeVisible();
 
 			// The new default persists to the backend (debounced write-level endpoint).
 			await expect
@@ -230,7 +284,7 @@ test.describe('v2 Home (MVP)', () => {
 					const res = await page.request.get('/tub/backend/public/api/settings/heat-target');
 					return (await res.json()).target_temp_f;
 				})
-				.toBe(103.5);
+				.toBe(103.25);
 		});
 
 		test('a Guest can heat to the default but gets no dial to rewrite it', async ({

--- a/frontend/e2e/v2-schedule.spec.ts
+++ b/frontend/e2e/v2-schedule.spec.ts
@@ -78,8 +78,8 @@ test.describe('v2 Schedule tab', () => {
 		await expect(card.getByTestId('event-oneoff-save')).toHaveCount(0);
 
 		// + temp updates the DRAFT and reveals Save — but the backend is untouched until Save.
-		await card.getByRole('button', { name: 'half a degree warmer' }).click();
-		await expect(card.getByTestId('event-oneoff-temp')).toHaveText('106.75°F');
+		await card.getByRole('button', { name: 'a quarter degree warmer' }).click();
+		await expect(card.getByTestId('event-oneoff-temp')).toHaveText('106.5°F');
 		await expect(card.getByTestId('event-oneoff-save')).toBeVisible();
 		expect(await tempOf(jobId)).toBe(106.25);
 
@@ -89,12 +89,12 @@ test.describe('v2 Schedule tab', () => {
 		await expect(card.getByTestId('event-oneoff-save')).toHaveCount(0);
 
 		// Re-nudge temp + time, then Save → persists in place (same job id), card goes clean.
-		await card.getByRole('button', { name: 'half a degree warmer' }).click();
+		await card.getByRole('button', { name: 'a quarter degree warmer' }).click();
 		await card.getByRole('button', { name: '15 minutes later' }).click();
 		await card.getByTestId('event-oneoff-save').click();
 		await expect(card.getByTestId('event-oneoff-save')).toHaveCount(0, { timeout: 10000 });
-		await expect(card.getByTestId('event-oneoff-temp')).toHaveText('106.75°F');
-		expect(await tempOf(jobId)).toBe(106.75);
+		await expect(card.getByTestId('event-oneoff-temp')).toHaveText('106.5°F');
+		expect(await tempOf(jobId)).toBe(106.50);
 
 		// Clean up.
 		await card.getByTestId('event-cancel').click();
@@ -134,8 +134,8 @@ test.describe('v2 Schedule tab', () => {
 
 		// Nudge time + temp: draft only — Skip next yields to Save/Discard, backend untouched.
 		await card.getByRole('button', { name: '15 minutes later' }).click();
-		await card.getByRole('button', { name: 'half a degree warmer' }).click();
-		await expect(card.getByTestId('event-oneoff-temp')).toHaveText('105.75°F');
+		await card.getByRole('button', { name: 'a quarter degree warmer' }).click();
+		await expect(card.getByTestId('event-oneoff-temp')).toHaveText('105.5°F');
 		await expect(card.getByTestId('event-skip')).toHaveCount(0);
 		expect((await jobOf())?.scheduledTime).toBe('06:30');
 
@@ -144,12 +144,75 @@ test.describe('v2 Schedule tab', () => {
 		await expect(card.getByTestId('event-oneoff-save')).toHaveCount(0, { timeout: 10000 });
 		const after = await jobOf();
 		expect(after?.scheduledTime).toBe('06:45');
-		expect(after?.params?.target_temp_f).toBe(105.75);
+		expect(after?.params?.target_temp_f).toBe(105.50);
 		await expect(card.getByTestId('event-skip')).toBeVisible(); // clean again
 
 		// Clean up.
 		await card.getByTestId('event-cancel').click();
 		await expect(card).toHaveCount(0, { timeout: 10000 });
+	});
+
+	test('a Home-created override folds into ONE adjusted card; permanent Save edits the daily default; Reset clears it', async ({
+		page
+	}) => {
+		// Create a daily heat via API (unique temp; past time so the next run is tomorrow),
+		// then override its next run — exactly what Home's card Save does.
+		const tz = await page.evaluate(() => Intl.DateTimeFormat().resolvedOptions().timeZone);
+		const past = new Date(Date.now() - 2 * 3600 * 1000);
+		const hhmm = `${String(past.getHours()).padStart(2, '0')}:${String(past.getMinutes()).padStart(2, '0')}`;
+		const res = await page.request.post('/tub/backend/public/api/schedule', {
+			data: {
+				action: 'heat-to-target',
+				scheduledTime: hhmm,
+				recurring: true,
+				target_temp_f: 103.75,
+				timezone: tz
+			}
+		});
+		expect(res.ok()).toBeTruthy();
+		const jobId = (await res.json()).jobId as string;
+
+		const plus15 = new Date(past.getTime() + 15 * 60 * 1000);
+		const overrideClock = `${String(plus15.getHours()).padStart(2, '0')}:${String(plus15.getMinutes()).padStart(2, '0')}`;
+		const ovRes = await page.request.post(
+			`/tub/backend/public/api/schedule/${jobId}/override-next`,
+			{ data: { scheduledTime: overrideClock, target_temp_f: 103.75 } }
+		);
+		expect(ovRes.ok()).toBeTruthy();
+
+		try {
+			await page.reload();
+			// ONE folded card wearing the adjusted badge — not a skipped parent plus an
+			// anonymous one-off (the confusing pair this fold replaces).
+			const card = page.locator(`[data-testid="event-card"][data-key="${jobId}"]`);
+			await expect(card).toHaveCount(1, { timeout: 10000 });
+			await expect(
+				page.locator('[data-testid="event-card"]', { hasText: 'Heat to 103.75' })
+			).toHaveCount(1);
+			await expect(card.getByTestId('event-adjusted')).toBeVisible();
+			await expect(card.getByTestId('event-resets-line')).toBeVisible();
+
+			const parentOf = async () => {
+				const list = (await (await page.request.get('/tub/backend/public/api/schedule')).json())
+					.jobs as Array<{ jobId: string; scheduledTime: string }>;
+				return list.find((j) => j.jobId === jobId);
+			};
+
+			// Plain Save here is PERMANENT: the steppers edit the daily default (the base
+			// job), and the override survives until reset.
+			await card.getByRole('button', { name: '15 minutes later' }).click();
+			await card.getByTestId('event-oneoff-save').click();
+			await expect(card.getByTestId('event-oneoff-save')).toHaveCount(0, { timeout: 10000 });
+			expect((await parentOf())?.scheduledTime).toBe(overrideClock); // daily hhmm + 15
+			await expect(card.getByTestId('event-adjusted')).toBeVisible(); // still adjusted
+
+			// Reset to daily clears the override; the card stays as the (updated) daily.
+			await card.getByTestId('event-reset').click();
+			await expect(card.getByTestId('event-adjusted')).toHaveCount(0, { timeout: 10000 });
+			await expect(card).toHaveCount(1);
+		} finally {
+			await page.request.delete(`/tub/backend/public/api/schedule/${jobId}`).catch(() => {});
+		}
 	});
 
 	test('leaving the tab with an unsaved one-off prompts; Discard abandons it', async ({ page }) => {
@@ -166,8 +229,8 @@ test.describe('v2 Schedule tab', () => {
 		const jobId = await card.getAttribute('data-job-id');
 
 		// Stage a temp change (dirty), then try to leave via the Home tab → guard prompts.
-		await card.getByRole('button', { name: 'half a degree warmer' }).click();
-		await expect(card.getByTestId('event-oneoff-temp')).toHaveText('107.75°F');
+		await card.getByRole('button', { name: 'a quarter degree warmer' }).click();
+		await expect(card.getByTestId('event-oneoff-temp')).toHaveText('107.5°F');
 		await page.getByTestId('tab-home').click();
 
 		const modal = page.getByTestId('unsaved-modal');

--- a/frontend/src/lib/components/EventCard.svelte
+++ b/frontend/src/lib/components/EventCard.svelte
@@ -1,97 +1,90 @@
 <script lang="ts">
 	import { onDestroy } from 'svelte';
-	import { type ScheduledJob } from '$lib/api';
 	import { getDynamicMode } from '$lib/stores/heatTargetSettings.svelte';
-	import { getNextOccurrence, formatNextFire } from '$lib/scheduleUtils';
+	import {
+		formatNextFire,
+		formatTemp,
+		formatClockHHMM,
+		shiftHHMM,
+		jobTitle,
+		jobClock,
+		resumeLabel,
+		baseSummary,
+		type LogicalEvent
+	} from '$lib/scheduleUtils';
 	import { registerPendingEdit, clearPendingEdit } from '$lib/stores/pendingEdits.svelte';
 
 	/**
-	 * A single scheduled heating event, rendered as a card (not a cramped row).
+	 * A single logical scheduled event, rendered as a card carrying its own controls —
+	 * the ONE schedule-adjustment paradigm, shared by the Schedule tab and Home's
+	 * Next-up zone (review F8).
 	 *
-	 * Shared by the Schedule tab (full controls) and Home's Next-up zone (compact).
 	 * Display is for everyone; the adjust controls only render when `canAdjust` is
-	 * true (User/Owner — Guests get no scheduling).
+	 * true (User/Owner — Guests get no scheduling). What Save means for a recurring
+	 * event is chosen by which callback the page passes:
+	 *  - `onOverrideNext` (Home): adjust just the next run — the daily default stays.
+	 *  - `onRescheduleRecurring` (Schedule tab): change the everyday default.
+	 * An overridden ("adjusted") card additionally offers Reset to daily
+	 * (`onClearOverride`) and Make permanent (`onMakePermanent`).
 	 */
 	interface Props {
-		job: ScheduledJob;
+		event: LogicalEvent;
 		canAdjust?: boolean;
-		compact?: boolean;
-		onSkip?: (jobId: string) => void;
-		onUnskip?: (jobId: string) => void;
-		onCancel?: (jobId: string) => void;
+		onSkip?: (event: LogicalEvent) => void;
+		onUnskip?: (event: LogicalEvent) => void;
+		onCancel?: (event: LogicalEvent) => void;
 		onSaveTemp?: (jobId: string, tempF: number) => Promise<void> | void;
 		onReschedule?: (jobId: string, scheduledTime: string, tempF?: number) => Promise<void> | void;
 		onRescheduleRecurring?: (jobId: string, time: string, tempF?: number) => Promise<void> | void;
+		onOverrideNext?: (jobId: string, time: string, tempF: number) => Promise<void> | void;
+		onClearOverride?: (event: LogicalEvent) => void;
+		onMakePermanent?: (event: LogicalEvent) => void;
 	}
 	let {
-		job,
+		event,
 		canAdjust = false,
-		compact = false,
 		onSkip,
 		onUnskip,
 		onCancel,
 		onSaveTemp,
 		onReschedule,
-		onRescheduleRecurring
+		onRescheduleRecurring,
+		onOverrideNext,
+		onClearOverride,
+		onMakePermanent
 	}: Props = $props();
 
-	const ACTION_LABELS: Record<string, string> = {
-		'heater-on': 'Heater on',
-		'heater-off': 'Heater off',
-		'pump-run': 'Run pump'
-	};
-
-	const isHeatToTarget = $derived(job.action === 'heat-to-target');
-
-	function formatTemp(t: number): string {
-		return Number.isInteger(t) ? `${t}` : t.toFixed(2).replace(/\.?0+$/, '');
-	}
-
-	// "Heat to 102.25°F" (or "~102°F" in dynamic mode); else the plain action name.
-	const title = $derived.by(() => {
-		if (isHeatToTarget && job.params?.target_temp_f != null) {
-			const tilde = getDynamicMode() ? '~' : '';
-			return `Heat to ${tilde}${formatTemp(job.params.target_temp_f)}°F`;
-		}
-		return ACTION_LABELS[job.action] ?? job.action;
-	});
+	// Adjustability is a property of the underlying schedule (the base job); the title
+	// and next-fire line describe the *effective* next run (the override when present).
+	const isHeatToTarget = $derived(event.baseJob.action === 'heat-to-target');
+	const title = $derived(jobTitle(event.job, getDynamicMode()));
 
 	// "ready by" when the recurring parent is in ready-by mode, else "start"/one-off.
-	const whenVerb = $derived(job.params?.ready_by_time ? 'ready by' : job.recurring ? 'start' : '');
+	const whenVerb = $derived(
+		event.baseJob.params?.ready_by_time ? 'ready by' : event.recurring ? 'start' : ''
+	);
 
 	// One when-line, no repeats: "Daily · start 6:30 AM · next Tomorrow" for recurring,
-	// "One-time · Tomorrow 3:00 PM" for one-offs. (An earlier cut said the same time three
-	// times per card.)
-	const nextOcc = $derived(getNextOccurrence(job));
-	const nextFire = $derived(formatNextFire(nextOcc));
+	// "One-time · Tomorrow 3:00 PM" for one-offs. For an adjusted card the clock is the
+	// effective next fire (the daily default lives on the resets-line below).
+	const nextFire = $derived(formatNextFire(event.nextFire));
 	const clockStr = $derived(
-		nextOcc.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+		event.nextFire.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
 	);
 	const nextDay = $derived(nextFire.slice(0, nextFire.length - clockStr.length).trim());
 	const whenLine = $derived(
-		job.recurring ? `Daily · ${whenVerb} ${clockStr} · next ${nextDay}` : `One-time · ${nextFire}`
+		event.recurring ? `Daily · ${whenVerb} ${clockStr} · next ${nextDay}` : `One-time · ${nextFire}`
 	);
 
-	function resumeLabel(iso?: string): string {
-		if (!iso) return '';
-		// Use the date part — skip/resume timestamps carry a misleading +00:00 offset
-		// (the date is the local calendar date), so `new Date(iso)` would land a day early.
-		const [y, mo, d] = iso.slice(0, 10).split('-').map(Number);
-		return new Date(y, mo - 1, d).toLocaleDateString(undefined, {
-			weekday: 'short',
-			month: 'short',
-			day: 'numeric'
-		});
-	}
-
-	// Inline temp editing (Schedule-tab "edit the everyday default").
+	// Inline temp editing (the "edit the everyday default" path for cards without
+	// steppers, e.g. a skipped heat card) — always targets the base job.
 	let editing = $state(false);
 	let tempValue = $state('');
 	let tempError = $state<string | null>(null);
 	let saving = $state(false);
 
 	function startEdit() {
-		tempValue = String(job.params?.target_temp_f ?? '');
+		tempValue = String(event.baseJob.params?.target_temp_f ?? '');
 		tempError = null;
 		editing = true;
 	}
@@ -108,7 +101,7 @@
 		saving = true;
 		tempError = null;
 		try {
-			await onSaveTemp?.(job.jobId, t);
+			await onSaveTemp?.(event.baseJob.jobId, t);
 			editing = false;
 		} catch (e) {
 			tempError = e instanceof Error ? e.message : 'Failed to save';
@@ -116,28 +109,37 @@
 			saving = false;
 		}
 	}
-	function onTempKeydown(event: KeyboardEvent) {
-		if (event.key === 'Enter') {
-			event.preventDefault();
+	function onTempKeydown(keyEvent: KeyboardEvent) {
+		if (keyEvent.key === 'Enter') {
+			keyEvent.preventDefault();
 			saveTemp();
-		} else if (event.key === 'Escape') {
-			event.preventDefault();
+		} else if (keyEvent.key === 'Escape') {
+			keyEvent.preventDefault();
 			cancelEdit();
 		}
 	}
 
-	// Quick ± time / ± temp adjust, staged locally and committed as ONE in-place
-	// reschedule. We never auto-send each tap — a reschedule rewrites the crontab (slow
-	// on the host) — so taps mutate a draft and Save commits it once. One-off and
-	// recurring heat events render the SAME steppers (card parity); they differ only in
-	// what Save means: move the instant vs. change the everyday daily time.
+	// Quick ± time / ± temp adjust, staged locally and committed as ONE backend call.
+	// We never auto-send each tap — every commit rewrites the crontab (slow on the
+	// host) — so taps mutate a draft and Save commits it once. One-off and recurring
+	// heat events render the SAME steppers (card parity); they differ only in what
+	// Save means: move the instant, override the next run, or change the daily default.
+	const overrideMode = $derived(!!onOverrideNext);
 	const oneOffAdjustable = $derived(
-		isHeatToTarget && !job.recurring && !getDynamicMode() && !!onReschedule
+		isHeatToTarget && !event.recurring && !getDynamicMode() && !!onReschedule
 	);
 	const recurringAdjustable = $derived(
-		isHeatToTarget && job.recurring && !job.skipped && !getDynamicMode() && !!onRescheduleRecurring
+		isHeatToTarget &&
+			event.recurring &&
+			!event.skipped &&
+			!getDynamicMode() &&
+			(overrideMode || !!onRescheduleRecurring)
 	);
 	const stepperAdjustable = $derived(oneOffAdjustable || recurringAdjustable);
+
+	// Override mode edits the *effective* next run (the override one-off when present);
+	// permanent mode edits the everyday default (the base job).
+	const stepperJob = $derived(event.recurring && !overrideMode ? event.baseJob : event.job);
 
 	const TEMP_MIN = 80;
 	const TEMP_MAX = 110;
@@ -149,35 +151,24 @@
 	const dirty = $derived(timeOffsetMin !== 0 || tempOffset !== 0);
 
 	// One-off: the draft is an instant. Recurring: the draft is a daily HH:MM wall clock,
-	// based on the user-facing time (the ready-by time for DTDT parents, whose
-	// scheduledTime is the earlier cron wake-up).
+	// based on the user-facing time (ready-by for DTDT jobs, whose scheduledTime is the
+	// earlier cron wake-up; the local clock for an override one-off).
 	const draftIso = $derived(
-		new Date(new Date(job.scheduledTime).getTime() + timeOffsetMin * 60_000).toISOString()
+		new Date(new Date(stepperJob.scheduledTime).getTime() + timeOffsetMin * 60_000).toISOString()
 	);
-	function shiftHHMM(hhmm: string, deltaMin: number): string {
-		const [h, m] = hhmm.split(':').map(Number);
-		const total = (h * 60 + m + deltaMin + 1440 * 100) % 1440;
-		const pad = (n: number) => String(n).padStart(2, '0');
-		return `${pad(Math.floor(total / 60))}:${pad(total % 60)}`;
-	}
-	const recurringBaseClock = $derived(job.params?.ready_by_time ?? job.scheduledTime);
+	const baseClockHHMM = $derived(jobClock(stepperJob));
 	const draftClockHHMM = $derived(
-		job.recurring ? shiftHHMM(recurringBaseClock, timeOffsetMin) : null
+		event.recurring ? shiftHHMM(baseClockHHMM, timeOffsetMin) : null
 	);
+	const baseTemp = $derived(stepperJob.params?.target_temp_f);
 	const draftTemp = $derived(
-		job.params?.target_temp_f != null
-			? Math.min(TEMP_MAX, Math.max(TEMP_MIN, job.params.target_temp_f + tempOffset))
-			: null
+		baseTemp != null ? Math.min(TEMP_MAX, Math.max(TEMP_MIN, baseTemp + tempOffset)) : null
 	);
-	const draftClockDisplay = $derived.by(() => {
-		if (job.recurring && draftClockHHMM) {
-			const [h, m] = draftClockHHMM.split(':').map(Number);
-			const d = new Date();
-			d.setHours(h, m, 0, 0);
-			return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-		}
-		return new Date(draftIso).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-	});
+	const draftClockDisplay = $derived(
+		event.recurring && draftClockHHMM
+			? formatClockHHMM(draftClockHHMM)
+			: new Date(draftIso).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+	);
 	let rescheduling = $state(false);
 	let rescheduleError = $state<string | null>(null);
 
@@ -191,11 +182,15 @@
 		rescheduling = true;
 		rescheduleError = null;
 		try {
-			const tempArg = tempOffset !== 0 && draftTemp != null ? draftTemp : undefined;
-			if (job.recurring) {
-				await onRescheduleRecurring?.(job.jobId, draftClockHHMM!, tempArg);
+			if (event.recurring && overrideMode) {
+				// override-next requires an explicit temp — send the effective one even untouched.
+				await onOverrideNext?.(event.key, draftClockHHMM!, draftTemp ?? baseTemp!);
+			} else if (event.recurring) {
+				const tempArg = tempOffset !== 0 && draftTemp != null ? draftTemp : undefined;
+				await onRescheduleRecurring?.(event.key, draftClockHHMM!, tempArg);
 			} else {
-				await onReschedule?.(job.jobId, draftIso, tempArg);
+				const tempArg = tempOffset !== 0 && draftTemp != null ? draftTemp : undefined;
+				await onReschedule?.(event.key, draftIso, tempArg);
 			}
 			// Committed — server is the new truth; go clean (the reload refreshes the base time).
 			timeOffsetMin = 0;
@@ -223,7 +218,7 @@
 		return `${title} → ${parts.join(' · ')}`;
 	}
 	$effect(() => {
-		const id = `card:${job.jobId}`;
+		const id = `card:${event.key}`;
 		if (dirty) {
 			registerPendingEdit({
 				id,
@@ -235,13 +230,14 @@
 			clearPendingEdit(id);
 		}
 	});
-	onDestroy(() => clearPendingEdit(`card:${job.jobId}`));
+	onDestroy(() => clearPendingEdit(`card:${event.key}`));
 </script>
 
 <div
 	data-testid="event-card"
-	data-job-id={job.jobId}
-	class="rounded-xl border p-3 {job.skipped
+	data-key={event.key}
+	data-job-id={event.job.jobId}
+	class="rounded-xl border p-3 {event.skipped
 		? 'border-amber-700/40 bg-amber-900/20'
 		: 'border-slate-700 bg-slate-800/50'}"
 >
@@ -249,7 +245,7 @@
 		<div class="min-w-0">
 			<div class="flex items-center gap-1.5">
 				<p class="truncate font-semibold text-slate-100" data-testid="event-title">{title}</p>
-				{#if job.recurring}
+				{#if event.recurring}
 					<svg
 						viewBox="0 0 24 24"
 						fill="none"
@@ -268,15 +264,24 @@
 				{/if}
 			</div>
 			<p class="text-sm text-slate-400" data-testid="event-when">{whenLine}</p>
-			{#if job.skipped}
+			{#if event.overridden}
+				<p class="mt-0.5 text-xs text-orange-300/80" data-testid="event-resets-line">
+					resets to {baseSummary(event)} daily
+				</p>
+			{:else if event.skipped}
 				<p class="mt-0.5 text-xs text-amber-300" data-testid="event-skip-state">
-					skips {resumeLabel(job.skipDate)} · resumes {resumeLabel(job.resumeDate)}
+					skips {resumeLabel(event.baseJob.skipDate)} · resumes {resumeLabel(event.resumeDate)}
 				</p>
 			{/if}
 		</div>
 
 		<!-- Badges mark exceptions only — every card saying "active" says nothing. -->
-		{#if !compact && job.skipped}
+		{#if event.overridden}
+			<span
+				class="shrink-0 rounded-full bg-orange-500/15 px-2 py-0.5 text-xs text-orange-300"
+				data-testid="event-adjusted">adjusted</span
+			>
+		{:else if event.skipped}
 			<span class="shrink-0 rounded-full bg-amber-500/15 px-2 py-0.5 text-xs text-amber-300"
 				>skipped</span
 			>
@@ -313,7 +318,8 @@
 			</div>
 		{:else if stepperAdjustable}
 			<!-- Heat-to-target quick ± time / temp adjust — identical for one-time and
-			     recurring (card parity); recurring adds Skip next below. -->
+			     recurring (card parity); clean recurring cards add Skip next / override
+			     management below. -->
 			<div class="mt-3 grid grid-cols-2 gap-2">
 				<div class="flex items-center justify-between rounded-lg bg-slate-900/50 px-2 py-1.5">
 					<button
@@ -337,8 +343,8 @@
 				<div class="flex items-center justify-between rounded-lg bg-slate-900/50 px-2 py-1.5">
 					<button
 						type="button"
-						aria-label="half a degree cooler"
-						onclick={() => nudge(0, -0.5)}
+						aria-label="a quarter degree cooler"
+						onclick={() => nudge(0, -0.25)}
 						disabled={rescheduling}
 						class="h-7 w-7 rounded text-lg leading-none text-slate-200 hover:bg-slate-700 disabled:opacity-40"
 						>&minus;</button
@@ -348,8 +354,8 @@
 					>
 					<button
 						type="button"
-						aria-label="half a degree warmer"
-						onclick={() => nudge(0, 0.5)}
+						aria-label="a quarter degree warmer"
+						onclick={() => nudge(0, 0.25)}
 						disabled={rescheduling}
 						class="h-7 w-7 rounded text-lg leading-none text-slate-200 hover:bg-slate-700 disabled:opacity-40"
 						>+</button
@@ -375,10 +381,25 @@
 						class="rounded-lg bg-orange-600 px-3 py-1 font-medium text-white hover:bg-orange-500 disabled:opacity-50"
 						>{rescheduling ? 'Saving…' : 'Save'}</button
 					>
+				{:else if event.overridden}
+					<button
+						type="button"
+						onclick={() => onClearOverride?.(event)}
+						data-testid="event-reset"
+						class="rounded-lg border border-slate-600 px-3 py-1 text-slate-300 hover:bg-slate-700"
+						>Reset to daily</button
+					>
+					<button
+						type="button"
+						onclick={() => onMakePermanent?.(event)}
+						data-testid="event-make-permanent"
+						class="rounded-lg border border-orange-600/50 px-3 py-1 text-orange-300 hover:bg-orange-600/10"
+						>Make permanent</button
+					>
 				{:else if recurringAdjustable}
 					<button
 						type="button"
-						onclick={() => onSkip?.(job.jobId)}
+						onclick={() => onSkip?.(event)}
 						data-testid="event-skip"
 						class="rounded-lg border border-slate-600 px-3 py-1 text-slate-300 hover:bg-slate-700"
 						>Skip next</button
@@ -386,7 +407,7 @@
 				{/if}
 				<button
 					type="button"
-					onclick={() => onCancel?.(job.jobId)}
+					onclick={() => onCancel?.(event)}
 					data-testid="event-cancel"
 					class="ml-auto rounded-lg px-3 py-1 text-slate-400 hover:bg-red-500/10 hover:text-red-300"
 					>Remove</button
@@ -394,11 +415,11 @@
 			</div>
 		{:else}
 			<div class="mt-3 flex flex-wrap items-center gap-2 text-sm">
-				{#if job.recurring}
-					{#if job.skipped}
+				{#if event.recurring}
+					{#if event.skipped}
 						<button
 							type="button"
-							onclick={() => onUnskip?.(job.jobId)}
+							onclick={() => onUnskip?.(event)}
 							data-testid="event-unskip"
 							class="rounded-lg border border-amber-600/50 px-3 py-1 text-amber-300 hover:bg-amber-600/10"
 							>Unskip</button
@@ -406,7 +427,7 @@
 					{:else}
 						<button
 							type="button"
-							onclick={() => onSkip?.(job.jobId)}
+							onclick={() => onSkip?.(event)}
 							data-testid="event-skip"
 							class="rounded-lg border border-slate-600 px-3 py-1 text-slate-300 hover:bg-slate-700"
 							>Skip next</button
@@ -424,7 +445,7 @@
 				{/if}
 				<button
 					type="button"
-					onclick={() => onCancel?.(job.jobId)}
+					onclick={() => onCancel?.(event)}
 					data-testid="event-cancel"
 					class="ml-auto rounded-lg px-3 py-1 text-slate-400 hover:bg-red-500/10 hover:text-red-300"
 					>Remove</button

--- a/frontend/src/lib/components/EventCard.test.ts
+++ b/frontend/src/lib/components/EventCard.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import EventCard from './EventCard.svelte';
+import { foldScheduledEvents, type LogicalEvent } from '$lib/scheduleUtils';
 import type { ScheduledJob } from '$lib/api';
 
-// Non-dynamic heat-to-target so the one-off ± adjust branch renders.
+// Non-dynamic heat-to-target so the ± adjust branch renders.
 vi.mock('$lib/stores/heatTargetSettings.svelte', () => ({
 	getDynamicMode: vi.fn(() => false)
 }));
@@ -14,6 +15,14 @@ vi.mock('$lib/stores/pendingEdits.svelte', () => ({
 	registerPendingEdit: vi.fn(),
 	clearPendingEdit: vi.fn()
 }));
+
+// Cards render logical events (the folded view both pages share), built through the
+// real fold so the tests exercise the same shapes production sees.
+function toEvent(...jobs: ScheduledJob[]): LogicalEvent {
+	const events = foldScheduledEvents(jobs);
+	expect(events).toHaveLength(1);
+	return events[0];
+}
 
 function oneOffJob(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
 	return {
@@ -26,51 +35,6 @@ function oneOffJob(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
 		...overrides
 	} as ScheduledJob;
 }
-
-describe('EventCard one-off staging', () => {
-	beforeEach(() => vi.clearAllMocks());
-
-	it('stages ± edits locally and only calls onReschedule on Save', async () => {
-		const onReschedule = vi.fn().mockResolvedValue(undefined);
-		render(EventCard, { props: { job: oneOffJob(), canAdjust: true, onReschedule } });
-
-		// Clean to start: no Save affordance.
-		expect(screen.queryByTestId('event-oneoff-save')).toBeNull();
-
-		// A ± tap updates the local draft display but does NOT hit the backend.
-		await fireEvent.click(screen.getByRole('button', { name: 'half a degree warmer' }));
-		expect(screen.getByTestId('event-oneoff-temp').textContent).toContain('105.5');
-		expect(onReschedule).not.toHaveBeenCalled();
-		expect(screen.queryByTestId('event-oneoff-save')).not.toBeNull();
-
-		await fireEvent.click(screen.getByRole('button', { name: '15 minutes later' }));
-		expect(onReschedule).not.toHaveBeenCalled();
-
-		// Save commits ONE call with the final time + temp.
-		await fireEvent.click(screen.getByTestId('event-oneoff-save'));
-		await waitFor(() => expect(onReschedule).toHaveBeenCalledTimes(1));
-		const [jobId, iso, temp] = onReschedule.mock.calls[0];
-		expect(jobId).toBe('job-1');
-		expect(temp).toBe(105.5);
-		expect(new Date(iso as string).getTime()).toBe(
-			new Date('2026-06-26T18:15:00-07:00').getTime()
-		);
-	});
-
-	it('Discard reverts the draft without calling onReschedule', async () => {
-		const onReschedule = vi.fn().mockResolvedValue(undefined);
-		render(EventCard, { props: { job: oneOffJob(), canAdjust: true, onReschedule } });
-
-		await fireEvent.click(screen.getByRole('button', { name: 'half a degree warmer' }));
-		expect(screen.getByTestId('event-oneoff-temp').textContent).toContain('105.5');
-
-		await fireEvent.click(screen.getByTestId('event-oneoff-discard'));
-		expect(screen.getByTestId('event-oneoff-temp').textContent).toContain('105');
-		expect(screen.getByTestId('event-oneoff-temp').textContent).not.toContain('105.5');
-		expect(onReschedule).not.toHaveBeenCalled();
-		expect(screen.queryByTestId('event-oneoff-save')).toBeNull();
-	});
-});
 
 function recurringJob(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
 	return {
@@ -85,13 +49,72 @@ function recurringJob(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
 	} as ScheduledJob;
 }
 
-describe('EventCard recurring staging (card parity)', () => {
+// An override one-off pointing at rec-1; the instant is built from local parts so the
+// derived wall clock is deterministic regardless of the test machine's timezone.
+function overrideJob(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
+	return {
+		jobId: 'ovr-1',
+		action: 'heat-to-target',
+		scheduledTime: new Date(2026, 5, 26, 7, 10).toISOString(),
+		createdAt: '2026-06-25T00:00:00Z',
+		recurring: false,
+		params: { target_temp_f: 102.25, override_of: 'rec-1' },
+		...overrides
+	} as ScheduledJob;
+}
+
+describe('EventCard one-off staging', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('stages ± edits locally and only calls onReschedule on Save', async () => {
+		const onReschedule = vi.fn().mockResolvedValue(undefined);
+		render(EventCard, { props: { event: toEvent(oneOffJob()), canAdjust: true, onReschedule } });
+
+		// Clean to start: no Save affordance.
+		expect(screen.queryByTestId('event-oneoff-save')).toBeNull();
+
+		// A ± tap updates the local draft display but does NOT hit the backend.
+		await fireEvent.click(screen.getByRole('button', { name: 'a quarter degree warmer' }));
+		expect(screen.getByTestId('event-oneoff-temp').textContent).toContain('105.25');
+		expect(onReschedule).not.toHaveBeenCalled();
+		expect(screen.queryByTestId('event-oneoff-save')).not.toBeNull();
+
+		await fireEvent.click(screen.getByRole('button', { name: '15 minutes later' }));
+		expect(onReschedule).not.toHaveBeenCalled();
+
+		// Save commits ONE call with the final time + temp.
+		await fireEvent.click(screen.getByTestId('event-oneoff-save'));
+		await waitFor(() => expect(onReschedule).toHaveBeenCalledTimes(1));
+		const [jobId, iso, temp] = onReschedule.mock.calls[0];
+		expect(jobId).toBe('job-1');
+		expect(temp).toBe(105.25);
+		expect(new Date(iso as string).getTime()).toBe(
+			new Date('2026-06-26T18:15:00-07:00').getTime()
+		);
+	});
+
+	it('Discard reverts the draft without calling onReschedule', async () => {
+		const onReschedule = vi.fn().mockResolvedValue(undefined);
+		render(EventCard, { props: { event: toEvent(oneOffJob()), canAdjust: true, onReschedule } });
+
+		await fireEvent.click(screen.getByRole('button', { name: 'a quarter degree warmer' }));
+		expect(screen.getByTestId('event-oneoff-temp').textContent).toContain('105.25');
+
+		await fireEvent.click(screen.getByTestId('event-oneoff-discard'));
+		expect(screen.getByTestId('event-oneoff-temp').textContent).toContain('105');
+		expect(screen.getByTestId('event-oneoff-temp').textContent).not.toContain('105.25');
+		expect(onReschedule).not.toHaveBeenCalled();
+		expect(screen.queryByTestId('event-oneoff-save')).toBeNull();
+	});
+});
+
+describe('EventCard recurring staging — permanent mode (Schedule tab)', () => {
 	beforeEach(() => vi.clearAllMocks());
 
 	it('renders the same ± steppers for a recurring heat event and stages locally', async () => {
 		const onRescheduleRecurring = vi.fn().mockResolvedValue(undefined);
 		render(EventCard, {
-			props: { job: recurringJob(), canAdjust: true, onRescheduleRecurring }
+			props: { event: toEvent(recurringJob()), canAdjust: true, onRescheduleRecurring }
 		});
 
 		// Clean: steppers present, Skip next visible, no Save yet, no legacy Edit temp.
@@ -102,20 +125,20 @@ describe('EventCard recurring staging (card parity)', () => {
 
 		// Nudge time + temp: draft updates, nothing hits the backend.
 		await fireEvent.click(screen.getByRole('button', { name: '15 minutes later' }));
-		await fireEvent.click(screen.getByRole('button', { name: 'half a degree warmer' }));
-		expect(screen.getByTestId('event-oneoff-temp').textContent).toContain('102.5');
+		await fireEvent.click(screen.getByRole('button', { name: 'a quarter degree warmer' }));
+		expect(screen.getByTestId('event-oneoff-temp').textContent).toContain('102.25');
 		expect(onRescheduleRecurring).not.toHaveBeenCalled();
 
 		// Save commits ONE call with the new daily HH:MM wall clock + temp.
 		await fireEvent.click(screen.getByTestId('event-oneoff-save'));
 		await waitFor(() => expect(onRescheduleRecurring).toHaveBeenCalledTimes(1));
-		expect(onRescheduleRecurring).toHaveBeenCalledWith('rec-1', '06:45', 102.5);
+		expect(onRescheduleRecurring).toHaveBeenCalledWith('rec-1', '06:45', 102.25);
 	});
 
 	it('time-only save leaves the temp argument undefined', async () => {
 		const onRescheduleRecurring = vi.fn().mockResolvedValue(undefined);
 		render(EventCard, {
-			props: { job: recurringJob(), canAdjust: true, onRescheduleRecurring }
+			props: { event: toEvent(recurringJob()), canAdjust: true, onRescheduleRecurring }
 		});
 
 		await fireEvent.click(screen.getByRole('button', { name: '15 minutes earlier' }));
@@ -128,10 +151,12 @@ describe('EventCard recurring staging (card parity)', () => {
 		const onRescheduleRecurring = vi.fn().mockResolvedValue(undefined);
 		render(EventCard, {
 			props: {
-				job: recurringJob({
-					scheduledTime: '03:35', // cron wake-up
-					params: { target_temp_f: 102, ready_by_time: '06:30' }
-				}),
+				event: toEvent(
+					recurringJob({
+						scheduledTime: '03:35', // cron wake-up
+						params: { target_temp_f: 102, ready_by_time: '06:30' }
+					})
+				),
 				canAdjust: true,
 				onRescheduleRecurring
 			}
@@ -146,15 +171,148 @@ describe('EventCard recurring staging (card parity)', () => {
 
 	it('a skipped recurring card keeps Unskip instead of steppers', () => {
 		const onRescheduleRecurring = vi.fn();
+		const onUnskip = vi.fn();
 		render(EventCard, {
 			props: {
-				job: recurringJob({ skipped: true, skipDate: '2026-06-27', resumeDate: '2026-06-28' }),
+				event: toEvent(
+					recurringJob({ skipped: true, skipDate: '2026-06-27', resumeDate: '2026-06-28' })
+				),
 				canAdjust: true,
-				onRescheduleRecurring
+				onRescheduleRecurring,
+				onUnskip
 			}
 		});
 
 		expect(screen.getByTestId('event-unskip')).toBeTruthy();
 		expect(screen.queryByRole('button', { name: '15 minutes later' })).toBeNull();
+	});
+
+	it('an overridden card in permanent mode seeds the steppers from the daily default', async () => {
+		const onRescheduleRecurring = vi.fn().mockResolvedValue(undefined);
+		render(EventCard, {
+			props: {
+				event: toEvent(recurringJob(), overrideJob()),
+				canAdjust: true,
+				onRescheduleRecurring
+			}
+		});
+
+		// Editing the everyday default (06:30), not the override's 07:10.
+		await fireEvent.click(screen.getByRole('button', { name: '15 minutes later' }));
+		await fireEvent.click(screen.getByTestId('event-oneoff-save'));
+		await waitFor(() => expect(onRescheduleRecurring).toHaveBeenCalledTimes(1));
+		expect(onRescheduleRecurring).toHaveBeenCalledWith('rec-1', '06:45', undefined);
+	});
+});
+
+describe('EventCard recurring staging — override mode (Home)', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('Save calls onOverrideNext with the temp always present', async () => {
+		const onOverrideNext = vi.fn().mockResolvedValue(undefined);
+		render(EventCard, {
+			props: { event: toEvent(recurringJob()), canAdjust: true, onOverrideNext }
+		});
+
+		// Time-only nudge still sends the effective temp — the override endpoint requires it.
+		await fireEvent.click(screen.getByRole('button', { name: '15 minutes later' }));
+		await fireEvent.click(screen.getByTestId('event-oneoff-save'));
+		await waitFor(() => expect(onOverrideNext).toHaveBeenCalledTimes(1));
+		expect(onOverrideNext).toHaveBeenCalledWith('rec-1', '06:45', 102);
+	});
+
+	it('an already-overridden card seeds the steppers from the effective next run', async () => {
+		const onOverrideNext = vi.fn().mockResolvedValue(undefined);
+		render(EventCard, {
+			props: {
+				event: toEvent(recurringJob(), overrideJob()),
+				canAdjust: true,
+				onOverrideNext
+			}
+		});
+
+		// Nudging the 07:10 override, not the 06:30 daily default.
+		await fireEvent.click(screen.getByRole('button', { name: '15 minutes later' }));
+		await fireEvent.click(screen.getByTestId('event-oneoff-save'));
+		await waitFor(() => expect(onOverrideNext).toHaveBeenCalledTimes(1));
+		expect(onOverrideNext).toHaveBeenCalledWith('rec-1', '07:25', 102.25);
+	});
+
+	it("uses the override's ready-by time as the stepper base when present", async () => {
+		const onOverrideNext = vi.fn().mockResolvedValue(undefined);
+		render(EventCard, {
+			props: {
+				event: toEvent(
+					recurringJob(),
+					overrideJob({ params: { target_temp_f: 102.25, ready_by_time: '07:30', override_of: 'rec-1' } })
+				),
+				canAdjust: true,
+				onOverrideNext
+			}
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: '15 minutes later' }));
+		await fireEvent.click(screen.getByTestId('event-oneoff-save'));
+		await waitFor(() => expect(onOverrideNext).toHaveBeenCalledTimes(1));
+		expect(onOverrideNext).toHaveBeenCalledWith('rec-1', '07:45', 102.25);
+	});
+});
+
+describe('EventCard overridden ("adjusted") card management', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	it('shows the adjusted badge and resets-line, never the skipped badge', () => {
+		render(EventCard, {
+			props: { event: toEvent(recurringJob(), overrideJob()), canAdjust: true, onOverrideNext: vi.fn() }
+		});
+
+		expect(screen.getByTestId('event-adjusted')).toBeTruthy();
+		expect(screen.getByTestId('event-resets-line').textContent).toContain('resets to');
+		expect(screen.queryByText('skipped')).toBeNull();
+		expect(screen.queryByTestId('event-skip-state')).toBeNull();
+	});
+
+	it('Reset to daily and Make permanent act on the logical event', async () => {
+		const onClearOverride = vi.fn();
+		const onMakePermanent = vi.fn();
+		render(EventCard, {
+			props: {
+				event: toEvent(recurringJob(), overrideJob()),
+				canAdjust: true,
+				onOverrideNext: vi.fn(),
+				onClearOverride,
+				onMakePermanent
+			}
+		});
+
+		await fireEvent.click(screen.getByTestId('event-reset'));
+		expect(onClearOverride).toHaveBeenCalledTimes(1);
+		expect(onClearOverride.mock.calls[0][0].key).toBe('rec-1');
+
+		await fireEvent.click(screen.getByTestId('event-make-permanent'));
+		expect(onMakePermanent).toHaveBeenCalledTimes(1);
+		expect(onMakePermanent.mock.calls[0][0].key).toBe('rec-1');
+	});
+
+	it('hides Reset to daily and Make permanent while the card is dirty', async () => {
+		render(EventCard, {
+			props: {
+				event: toEvent(recurringJob(), overrideJob()),
+				canAdjust: true,
+				onOverrideNext: vi.fn().mockResolvedValue(undefined),
+				onClearOverride: vi.fn(),
+				onMakePermanent: vi.fn()
+			}
+		});
+
+		expect(screen.getByTestId('event-reset')).toBeTruthy();
+		expect(screen.getByTestId('event-make-permanent')).toBeTruthy();
+
+		// Dirty: Save/Discard take over the row.
+		await fireEvent.click(screen.getByRole('button', { name: '15 minutes later' }));
+		expect(screen.queryByTestId('event-reset')).toBeNull();
+		expect(screen.queryByTestId('event-make-permanent')).toBeNull();
+		expect(screen.getByTestId('event-oneoff-save')).toBeTruthy();
+		expect(screen.getByTestId('event-oneoff-discard')).toBeTruthy();
 	});
 });

--- a/frontend/src/lib/scheduleActions.test.ts
+++ b/frontend/src/lib/scheduleActions.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { skipEvent, cancelEvent, makePermanentEvent } from './scheduleActions';
+import { foldScheduledEvents, type LogicalEvent } from './scheduleUtils';
+import { api, type ScheduledJob } from './api';
+
+vi.mock('./api', () => ({
+	api: {
+		clearOverrideNext: vi.fn(),
+		skipScheduledJob: vi.fn(),
+		cancelScheduledJob: vi.fn(),
+		rescheduleRecurring: vi.fn()
+	}
+}));
+
+function recurringJob(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
+	return {
+		jobId: 'rec-1',
+		action: 'heat-to-target',
+		scheduledTime: '06:30',
+		createdAt: '2026-06-20T00:00:00Z',
+		recurring: true,
+		timezone: 'America/Los_Angeles',
+		params: { target_temp_f: 102 },
+		...overrides
+	} as ScheduledJob;
+}
+
+// Local-parts instant so the derived wall clock is timezone-independent.
+function overrideJob(overrides: Partial<ScheduledJob> = {}): ScheduledJob {
+	return {
+		jobId: 'ovr-1',
+		action: 'heat-to-target',
+		scheduledTime: new Date(2026, 5, 26, 7, 10).toISOString(),
+		createdAt: '2026-06-25T00:00:00Z',
+		recurring: false,
+		params: { target_temp_f: 102.25, override_of: 'rec-1' },
+		...overrides
+	} as ScheduledJob;
+}
+
+function toEvent(...jobs: ScheduledJob[]): LogicalEvent {
+	const events = foldScheduledEvents(jobs);
+	expect(events).toHaveLength(1);
+	return events[0];
+}
+
+const plainEvent = () => toEvent(recurringJob());
+const overriddenEvent = () => toEvent(recurringJob(), overrideJob());
+
+function callOrder(fn: ReturnType<typeof vi.fn>): number {
+	return fn.mock.invocationCallOrder[0];
+}
+
+describe('skipEvent', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(api.clearOverrideNext).mockResolvedValue(undefined as never);
+		vi.mocked(api.skipScheduledJob).mockResolvedValue(undefined as never);
+	});
+
+	it('skips a plain recurring event without touching overrides', async () => {
+		await skipEvent(plainEvent());
+		expect(api.skipScheduledJob).toHaveBeenCalledWith('rec-1');
+		expect(api.clearOverrideNext).not.toHaveBeenCalled();
+	});
+
+	it('drops the override before skipping an adjusted event', async () => {
+		await skipEvent(overriddenEvent());
+		expect(api.clearOverrideNext).toHaveBeenCalledWith('rec-1');
+		expect(api.skipScheduledJob).toHaveBeenCalledWith('rec-1');
+		expect(callOrder(vi.mocked(api.clearOverrideNext))).toBeLessThan(
+			callOrder(vi.mocked(api.skipScheduledJob))
+		);
+	});
+
+	it('still skips when clearing the override fails', async () => {
+		vi.mocked(api.clearOverrideNext).mockRejectedValue(new Error('boom'));
+		await skipEvent(overriddenEvent());
+		expect(api.skipScheduledJob).toHaveBeenCalledWith('rec-1');
+	});
+});
+
+describe('cancelEvent', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(api.clearOverrideNext).mockResolvedValue(undefined as never);
+		vi.mocked(api.cancelScheduledJob).mockResolvedValue(undefined as never);
+	});
+
+	it('cancels a plain event directly', async () => {
+		await cancelEvent(plainEvent());
+		expect(api.cancelScheduledJob).toHaveBeenCalledWith('rec-1');
+		expect(api.clearOverrideNext).not.toHaveBeenCalled();
+	});
+
+	it('clears the override before cancelling, so no ghost one-off survives', async () => {
+		await cancelEvent(overriddenEvent());
+		expect(api.clearOverrideNext).toHaveBeenCalledWith('rec-1');
+		expect(api.cancelScheduledJob).toHaveBeenCalledWith('rec-1');
+		expect(callOrder(vi.mocked(api.clearOverrideNext))).toBeLessThan(
+			callOrder(vi.mocked(api.cancelScheduledJob))
+		);
+	});
+
+	it('does not cancel when clearing the override fails', async () => {
+		vi.mocked(api.clearOverrideNext).mockRejectedValue(new Error('boom'));
+		await expect(cancelEvent(overriddenEvent())).rejects.toThrow('boom');
+		expect(api.cancelScheduledJob).not.toHaveBeenCalled();
+	});
+});
+
+describe('makePermanentEvent', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.mocked(api.rescheduleRecurring).mockResolvedValue(undefined as never);
+		vi.mocked(api.clearOverrideNext).mockResolvedValue(undefined as never);
+	});
+
+	it("promotes the override's local wall clock and temp to the daily default, then clears", async () => {
+		await makePermanentEvent(overriddenEvent());
+		expect(api.rescheduleRecurring).toHaveBeenCalledWith('rec-1', '07:10', 102.25);
+		expect(api.clearOverrideNext).toHaveBeenCalledWith('rec-1');
+		expect(callOrder(vi.mocked(api.rescheduleRecurring))).toBeLessThan(
+			callOrder(vi.mocked(api.clearOverrideNext))
+		);
+	});
+
+	it("prefers the override's ready-by time when present", async () => {
+		const e = toEvent(
+			recurringJob(),
+			overrideJob({ params: { target_temp_f: 102.25, ready_by_time: '07:30', override_of: 'rec-1' } })
+		);
+		await makePermanentEvent(e);
+		expect(api.rescheduleRecurring).toHaveBeenCalledWith('rec-1', '07:30', 102.25);
+	});
+
+	it('does not clear the override when the promotion fails — Reset-to-daily can still recover', async () => {
+		vi.mocked(api.rescheduleRecurring).mockRejectedValue(new Error('boom'));
+		await expect(makePermanentEvent(overriddenEvent())).rejects.toThrow('boom');
+		expect(api.clearOverrideNext).not.toHaveBeenCalled();
+	});
+
+	it('is a no-op for an event without an override', async () => {
+		await makePermanentEvent(plainEvent());
+		expect(api.rescheduleRecurring).not.toHaveBeenCalled();
+		expect(api.clearOverrideNext).not.toHaveBeenCalled();
+	});
+});

--- a/frontend/src/lib/scheduleActions.ts
+++ b/frontend/src/lib/scheduleActions.ts
@@ -1,0 +1,46 @@
+import { api } from './api';
+import { jobClock, type LogicalEvent } from './scheduleUtils';
+
+/**
+ * Composed schedule actions over logical events, shared by Home and the Schedule tab.
+ *
+ * The backend models an "adjust just the next run" override as a skipped recurring
+ * parent + a one-off, and its skip/cancel endpoints don't cascade to that one-off —
+ * so acting on an adjusted event takes two calls. They run SEQUENTIALLY on purpose:
+ * every call rewrites the crontab (slow on the host) and concurrent rewrites race.
+ *
+ * These are pure API compositions; callers own the reload and error toast.
+ */
+
+/**
+ * Skip the next run. An existing override is dropped first (skipping an adjusted
+ * event means "don't run at all", not "run at the adjusted time"); if that cleanup
+ * fails the skip still proceeds.
+ */
+export async function skipEvent(e: LogicalEvent): Promise<void> {
+	if (e.overridden) await api.clearOverrideNext(e.key).catch(() => {});
+	await api.skipScheduledJob(e.key);
+}
+
+/**
+ * Remove the event. An existing override is cleared first — cancelling the parent
+ * alone would orphan the override one-off, which would then fire (and render) as a
+ * ghost event. A failed clear aborts the removal.
+ */
+export async function cancelEvent(e: LogicalEvent): Promise<void> {
+	if (e.overridden) await api.clearOverrideNext(e.key);
+	await api.cancelScheduledJob(e.key);
+}
+
+/**
+ * Promote an override into the everyday default: reschedule the recurring parent to
+ * the override's wall clock + temp, then clear the override. Promote FIRST — if the
+ * clear fails, the leftover override fires at the same time/temp and Reset-to-daily
+ * recovers; the reverse order could lose the user's adjustment.
+ */
+export async function makePermanentEvent(e: LogicalEvent): Promise<void> {
+	const override = e.overrideJob;
+	if (!override) return;
+	await api.rescheduleRecurring(e.key, jobClock(override), override.params?.target_temp_f);
+	await api.clearOverrideNext(e.key);
+}

--- a/frontend/src/lib/scheduleUtils.test.ts
+++ b/frontend/src/lib/scheduleUtils.test.ts
@@ -4,7 +4,15 @@ import {
 	getTimezoneOffset,
 	getNextOccurrence,
 	formatNextFire,
-	foldScheduledEvents
+	foldScheduledEvents,
+	formatTemp,
+	shiftHHMM,
+	formatClockHHMM,
+	jobTitle,
+	resumeLabel,
+	jobClock,
+	baseSummary,
+	oneOffIso
 } from './scheduleUtils';
 import type { ScheduledJob } from './api';
 
@@ -321,6 +329,170 @@ describe('scheduleUtils', () => {
 			expect(events[0].key).toBe('job-9');
 			// It's a real heat-to-target one-off, so it can still be moved in place from Home.
 			expect(events[0].adjustable).toBe(true);
+		});
+	});
+
+	// Shared display/clock helpers, consolidated from Home and EventCard (review F10).
+	describe('formatTemp', () => {
+		it('drops the decimals from whole degrees', () => {
+			expect(formatTemp(102)).toBe('102');
+		});
+
+		it('keeps quarter-degree precision without trailing zeros', () => {
+			expect(formatTemp(102.25)).toBe('102.25');
+			expect(formatTemp(102.5)).toBe('102.5');
+		});
+	});
+
+	describe('shiftHHMM', () => {
+		it('shifts within the day', () => {
+			expect(shiftHHMM('06:55', 15)).toBe('07:10');
+			expect(shiftHHMM('06:55', -15)).toBe('06:40');
+		});
+
+		it('wraps forward past midnight', () => {
+			expect(shiftHHMM('23:45', 15)).toBe('00:00');
+		});
+
+		it('wraps backward past midnight, even for repeated large steps', () => {
+			expect(shiftHHMM('00:00', -15)).toBe('23:45');
+			expect(shiftHHMM('00:00', -1440 * 3)).toBe('00:00');
+		});
+	});
+
+	describe('formatClockHHMM', () => {
+		it('renders an HH:MM wall clock in the locale time format', () => {
+			const expected = new Date(2026, 0, 1, 6, 55).toLocaleTimeString(undefined, {
+				hour: 'numeric',
+				minute: '2-digit'
+			});
+			expect(formatClockHHMM('06:55')).toBe(expected);
+		});
+	});
+
+	describe('jobTitle', () => {
+		const heatJob = {
+			jobId: 'j1',
+			action: 'heat-to-target',
+			scheduledTime: '06:55',
+			createdAt: '2026-06-20T00:00:00Z',
+			recurring: true,
+			params: { target_temp_f: 102.25 }
+		} as ScheduledJob;
+
+		it('names a heat-to-target job by its target', () => {
+			expect(jobTitle(heatJob, false)).toBe('Heat to 102.25°F');
+		});
+
+		it('marks the target approximate in dynamic mode', () => {
+			expect(jobTitle(heatJob, true)).toBe('Heat to ~102.25°F');
+		});
+
+		it('uses the action label for non-target jobs', () => {
+			expect(jobTitle({ ...heatJob, action: 'pump-run', params: undefined }, false)).toBe(
+				'Run pump'
+			);
+		});
+
+		it('falls back to the raw action name', () => {
+			expect(jobTitle({ ...heatJob, action: 'mystery-op', params: undefined }, false)).toBe(
+				'mystery-op'
+			);
+		});
+	});
+
+	describe('resumeLabel', () => {
+		it('formats the calendar date, immune to the misleading +00:00 offset', () => {
+			// The stored date part is the local calendar date; naive Date parsing could
+			// land a day early west of UTC.
+			const label = resumeLabel('2026-06-27T06:55:00+00:00');
+			expect(label).toContain('27');
+			expect(label).toContain('Jun');
+		});
+
+		it('returns an empty string for a missing date', () => {
+			expect(resumeLabel(undefined)).toBe('');
+		});
+	});
+
+	describe('jobClock', () => {
+		it('prefers the ready-by time', () => {
+			const job = {
+				jobId: 'j1',
+				action: 'heat-to-target',
+				scheduledTime: '05:40',
+				createdAt: '2026-06-20T00:00:00Z',
+				recurring: true,
+				params: { target_temp_f: 102, ready_by_time: '07:30' }
+			} as ScheduledJob;
+			expect(jobClock(job)).toBe('07:30');
+		});
+
+		it('uses the recurring HH:MM directly', () => {
+			const job = {
+				jobId: 'j1',
+				action: 'heat-to-target',
+				scheduledTime: '06:55',
+				createdAt: '2026-06-20T00:00:00Z',
+				recurring: true
+			} as ScheduledJob;
+			expect(jobClock(job)).toBe('06:55');
+		});
+
+		it('derives a padded local wall clock from a one-off instant', () => {
+			const job = {
+				jobId: 'j1',
+				action: 'heat-to-target',
+				scheduledTime: new Date(2026, 5, 26, 7, 5).toISOString(),
+				createdAt: '2026-06-20T00:00:00Z',
+				recurring: false
+			} as ScheduledJob;
+			expect(jobClock(job)).toBe('07:05');
+		});
+	});
+
+	describe('baseSummary', () => {
+		it('summarizes the everyday default as clock · temp', () => {
+			const base = {
+				jobId: 'rec-1',
+				action: 'heat-to-target',
+				scheduledTime: '06:55',
+				createdAt: '2026-06-20T00:00:00Z',
+				recurring: true,
+				params: { target_temp_f: 102.25 }
+			} as ScheduledJob;
+			const [event] = foldScheduledEvents([base]);
+			expect(baseSummary(event)).toBe(`${formatClockHHMM('06:55')} · 102.25°F`);
+		});
+
+		it('omits the temp when the base job has none', () => {
+			const base = {
+				jobId: 'rec-1',
+				action: 'pump-run',
+				scheduledTime: '21:00',
+				createdAt: '2026-06-20T00:00:00Z',
+				recurring: true
+			} as ScheduledJob;
+			const [event] = foldScheduledEvents([base]);
+			expect(baseSummary(event)).toBe(formatClockHHMM('21:00'));
+		});
+	});
+
+	describe('oneOffIso', () => {
+		it("recomposes the job's calendar date with a new local wall clock", () => {
+			const job = {
+				jobId: 'j1',
+				action: 'heat-to-target',
+				scheduledTime: new Date(2026, 5, 26, 7, 5).toISOString(),
+				createdAt: '2026-06-20T00:00:00Z',
+				recurring: false
+			} as ScheduledJob;
+			const result = new Date(oneOffIso(job, '19:30'));
+			expect(result.getFullYear()).toBe(2026);
+			expect(result.getMonth()).toBe(5);
+			expect(result.getDate()).toBe(26);
+			expect(result.getHours()).toBe(19);
+			expect(result.getMinutes()).toBe(30);
 		});
 	});
 });

--- a/frontend/src/lib/scheduleUtils.ts
+++ b/frontend/src/lib/scheduleUtils.ts
@@ -294,6 +294,103 @@ export function foldScheduledEvents(jobs: ScheduledJob[], now: Date = new Date()
 	return events.sort((a, b) => a.nextFire.getTime() - b.nextFire.getTime());
 }
 
+// ── Shared display/clock helpers (consolidated from Home and EventCard — review F10) ──
+
+const pad2 = (n: number): string => String(n).padStart(2, '0');
+
+/**
+ * Format a temperature without trailing zeros: 102 → "102", 102.25 → "102.25".
+ */
+export function formatTemp(t: number): string {
+	return Number.isInteger(t) ? `${t}` : t.toFixed(2).replace(/\.?0+$/, '');
+}
+
+/**
+ * Shift an "HH:MM" wall clock by whole minutes, wrapping at midnight in either
+ * direction (safe against arbitrarily large negative deltas).
+ */
+export function shiftHHMM(hhmm: string, deltaMin: number): string {
+	const { hours, minutes } = parseClockTime(hhmm);
+	const total = (hours * 60 + minutes + deltaMin + 1440 * 100) % 1440;
+	return `${pad2(Math.floor(total / 60))}:${pad2(total % 60)}`;
+}
+
+/**
+ * Render an "HH:MM" wall clock in the locale time format ("06:55" → "6:55 AM").
+ */
+export function formatClockHHMM(hhmm: string): string {
+	const { hours, minutes } = parseClockTime(hhmm);
+	const d = new Date();
+	d.setHours(hours, minutes, 0, 0);
+	return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+}
+
+const ACTION_LABELS: Record<string, string> = {
+	'heater-on': 'Heater on',
+	'heater-off': 'Heater off',
+	'pump-run': 'Run pump'
+};
+
+/**
+ * "Heat to 102.25°F" (with `tilde` for dynamic-mode approximate targets), else the
+ * plain action label. The caller passes the dynamic-mode flag — this module must
+ * stay free of store imports.
+ */
+export function jobTitle(job: ScheduledJob, tilde: boolean): string {
+	if (job.action === 'heat-to-target' && job.params?.target_temp_f != null) {
+		return `Heat to ${tilde ? '~' : ''}${formatTemp(job.params.target_temp_f)}°F`;
+	}
+	return ACTION_LABELS[job.action] ?? job.action;
+}
+
+/**
+ * Format a skip/resume date. Uses the date part only — those timestamps carry a
+ * misleading +00:00 offset (the date is the local calendar date), so `new Date(iso)`
+ * would land a day early west of UTC.
+ */
+export function resumeLabel(iso?: string): string {
+	if (!iso) return '';
+	const [y, mo, d] = iso.slice(0, 10).split('-').map(Number);
+	return new Date(y, mo - 1, d).toLocaleDateString(undefined, {
+		weekday: 'short',
+		month: 'short',
+		day: 'numeric'
+	});
+}
+
+/**
+ * The user-facing "HH:MM" wall clock of a job: its ready-by time, the recurring
+ * HH:MM, else the one-off instant's local clock.
+ */
+export function jobClock(job: ScheduledJob): string {
+	if (job.params?.ready_by_time) return job.params.ready_by_time;
+	if (job.recurring) return job.scheduledTime;
+	const d = new Date(job.scheduledTime);
+	return `${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+}
+
+/**
+ * "6:55 AM · 102.25°F" — the everyday default that an override leaves untouched.
+ */
+export function baseSummary(e: LogicalEvent): string {
+	const parts = [formatClockHHMM(jobClock(e.baseJob))];
+	if (e.baseJob.params?.target_temp_f != null) {
+		parts.push(`${formatTemp(e.baseJob.params.target_temp_f)}°F`);
+	}
+	return parts.join(' · ');
+}
+
+/**
+ * Recompose a one-off's instant from its existing calendar date + a new local "HH:MM",
+ * so a nudge moves it in place via rescheduleOneOff. Nudges stay within the day.
+ */
+export function oneOffIso(job: ScheduledJob, clock: string): string {
+	const d = new Date(job.scheduledTime);
+	const { hours, minutes } = parseClockTime(clock);
+	d.setHours(hours, minutes, 0, 0);
+	return d.toISOString();
+}
+
 /**
  * Quick schedule options available in the UI
  */

--- a/frontend/src/routes/v2/+page.svelte
+++ b/frontend/src/routes/v2/+page.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
-	import { onMount, onDestroy } from 'svelte';
+	import { onMount } from 'svelte';
 	import { goto } from '$app/navigation';
 	import { base } from '$app/paths';
-	import UnsavedChangesModal from '$lib/components/UnsavedChangesModal.svelte';
-	import { registerPendingEdit, clearPendingEdit } from '$lib/stores/pendingEdits.svelte';
 	import CompactControlButton from '$lib/components/CompactControlButton.svelte';
 	import EquipmentStatusBar from '$lib/components/EquipmentStatusBar.svelte';
 	import TemperaturePanel from '$lib/components/TemperaturePanel.svelte';
+	import EventCard from '$lib/components/EventCard.svelte';
 	import { api, type TargetTemperatureState, type ScheduledJob } from '$lib/api';
 	import { canControl, canSchedule, canTuneTarget } from '$lib/roles';
-	import { foldScheduledEvents, formatNextFire, type LogicalEvent } from '$lib/scheduleUtils';
+	import { foldScheduledEvents, type LogicalEvent } from '$lib/scheduleUtils';
+	import { skipEvent, cancelEvent, makePermanentEvent } from '$lib/scheduleActions';
 	import {
 		fetchStatus,
 		getHeaterOn,
@@ -42,7 +42,7 @@
 	// dynamic (an absolute dial is meaningless against an ambient-derived target).
 	// Owner/User only: the dial rewrites the *persistent household default* — a Guest
 	// heats to it but doesn't redefine it (roles.canTuneTarget).
-	const TEMP_STEP_F = 0.5;
+	const TEMP_STEP_F = 0.25;
 	let targetEnabled = $derived(getTargetTempEnabled());
 	let dynamicMode = $derived(getDynamicMode());
 	let showDial = $derived(canTuneTarget(data.user?.role) && targetEnabled && !dynamicMode);
@@ -86,96 +86,13 @@
 
 	// ── Next up ────────────────────────────────────────────────────────────────
 	// Upcoming events, folded so each recurring event (with or without an override)
-	// is ONE card. Display is for everyone; the adjust controls are User/Owner only.
+	// is ONE card. Each card carries its own controls (EventCard — the same paradigm
+	// as the Schedule tab). Display is for everyone; the adjust controls are
+	// User/Owner only. Here a recurring Save means "override just the next run"
+	// (onOverrideNext); the daily default changes only via Make permanent.
 	let scheduledJobs = $state<ScheduledJob[]>([]);
 	const events = $derived(foldScheduledEvents(scheduledJobs));
 	const canSched = $derived(canSchedule(data.user?.role));
-
-	// Selection is keyed by the *stable* logical-event key (the recurring parent id),
-	// so it survives the override churn instead of re-binding to whatever sorts to the top.
-	let selectedKey = $state<string | null>(null);
-	const selected = $derived(events.find((e) => e.key === selectedKey) ?? null);
-	let adjusting = $state(false);
-
-	// Keep a valid selection: if the selected card disappears, fall back to the soonest
-	// adjustable event so the common case ("tweak the next run") needs no extra tap.
-	$effect(() => {
-		if (!canSched) return;
-		if (selectedKey && events.some((e) => e.key === selectedKey)) return;
-		const firstAdjustable = events.find((e) => e.adjustable);
-		selectedKey = firstAdjustable?.key ?? events[0]?.key ?? null;
-	});
-
-	const TEMP_MIN = 80;
-	const TEMP_MAX = 110;
-	const clampTemp = (t: number) => Math.min(TEMP_MAX, Math.max(TEMP_MIN, t));
-	const pad2 = (n: number) => String(n).padStart(2, '0');
-
-	function formatTemp(t: number): string {
-		return Number.isInteger(t) ? `${t}` : t.toFixed(2).replace(/\.?0+$/, '');
-	}
-	function formatClock(hhmm: string): string {
-		const [h, m] = hhmm.split(':').map(Number);
-		const d = new Date();
-		d.setHours(h, m, 0, 0);
-		return d.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
-	}
-	function shiftClock(hhmm: string, deltaMin: number): string {
-		const [h, m] = hhmm.split(':').map(Number);
-		const total = (h * 60 + m + deltaMin + 1440) % 1440;
-		return `${pad2(Math.floor(total / 60))}:${pad2(total % 60)}`;
-	}
-	// Recompose a one-off's instant from its existing calendar date + a new local HH:MM, so a
-	// Home nudge moves it in place via rescheduleOneOff. Nudges stay within the day; a larger
-	// move belongs on the Schedule tab.
-	function oneOffIso(job: ScheduledJob, clock: string): string {
-		const d = new Date(job.scheduledTime);
-		const [h, m] = clock.split(':').map(Number);
-		d.setHours(h, m, 0, 0);
-		return d.toISOString();
-	}
-
-	const ACTION_LABELS: Record<string, string> = {
-		'heater-on': 'Heater on',
-		'heater-off': 'Heater off',
-		'pump-run': 'Run pump'
-	};
-	function jobTitle(job: ScheduledJob): string {
-		if (job.action === 'heat-to-target' && job.params?.target_temp_f != null) {
-			const tilde = getDynamicMode() ? '~' : '';
-			return `Heat to ${tilde}${formatTemp(job.params.target_temp_f)}°F`;
-		}
-		return ACTION_LABELS[job.action] ?? job.action;
-	}
-
-	// Clock time of a job: ready-by time, the recurring HH:MM, else the one-off's local clock.
-	function jobClock(job: ScheduledJob): string {
-		if (job.params?.ready_by_time) return job.params.ready_by_time;
-		if (job.recurring) return job.scheduledTime;
-		const d = new Date(job.scheduledTime);
-		return `${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
-	}
-	const eventTemp = (e: LogicalEvent) => e.job.params?.target_temp_f ?? getTargetTempF();
-
-	// "6:55 AM · 102.25°F" — the everyday default that an override leaves untouched.
-	function baseSummary(e: LogicalEvent): string {
-		const parts = [formatClock(jobClock(e.baseJob))];
-		if (e.baseJob.params?.target_temp_f != null) {
-			parts.push(`${formatTemp(e.baseJob.params.target_temp_f)}°F`);
-		}
-		return parts.join(' · ');
-	}
-	function resumeLabel(iso?: string): string {
-		if (!iso) return '';
-		// Use the date part — skip/resume timestamps carry a misleading +00:00 offset.
-		const [y, mo, d] = iso.slice(0, 10).split('-').map(Number);
-		return new Date(y, mo - 1, d).toLocaleDateString(undefined, {
-			weekday: 'short',
-			month: 'short',
-			day: 'numeric'
-		});
-	}
-	const skipLabel = (e: LogicalEvent) => resumeLabel(e.baseJob.skipDate);
 
 	async function reloadJobs() {
 		try {
@@ -191,174 +108,56 @@
 		setTimeout(() => (status = null), 3000);
 	}
 
-	// Staged next-run edit for the selected card. The ± steppers mutate this draft; an
-	// explicit Save commits it as ONE override (skip + one-off) — we never auto-send each
-	// tap, since an override rewrites the crontab (slow on the host). See pendingEdits.svelte.
-	let draftClock = $state<string | null>(null);
-	let draftTemp = $state<number | null>(null);
-
-	// Re-seed the draft whenever the selection (or its underlying job) changes, so switching
-	// cards or reloading after Save starts clean. Reads `selected` only — mutating the draft
-	// can't feed back into this effect.
-	$effect(() => {
-		const e = selected;
-		draftClock = e ? jobClock(e.job) : null;
-		draftTemp = e ? eventTemp(e) : null;
-	});
-
-	const homeDirty = $derived(
-		!!selected &&
-			selected.adjustable &&
-			!selected.skipped &&
-			(draftClock !== jobClock(selected.job) || draftTemp !== eventTemp(selected))
-	);
-
-	function draftSummary(): string {
-		const e = selected;
-		if (!e) return 'Next run change';
-		const tail = draftTemp != null ? ` · ${formatTemp(draftTemp)}°F` : '';
-		return `${jobTitle(e.job)} → ${formatClock(draftClock ?? jobClock(e.job))}${tail}`;
+	// Reschedule paths: errors propagate to the card, which shows them inline (and
+	// rethrows so the navigation guard's Save-all halts on failure).
+	async function handleOverrideNext(jobId: string, clock: string, tempF: number) {
+		await api.overrideNextOccurrence(jobId, clock, tempF);
+		await reloadJobs();
+	}
+	async function handleRescheduleOneOff(jobId: string, scheduledTime: string, tempF?: number) {
+		await api.rescheduleOneOff(jobId, scheduledTime, tempF);
+		await reloadJobs();
 	}
 
-	// All actions operate on the SELECTED event's stable key — never a sort position.
-	// ± taps mutate the local draft only; nothing hits the backend until Save.
-	function adjustSelected(deltaMin: number, deltaTemp: number) {
-		const e = selected;
-		if (!e || !e.adjustable || e.skipped) return;
-		if (deltaMin) draftClock = shiftClock(draftClock ?? jobClock(e.job), deltaMin);
-		if (deltaTemp) draftTemp = clampTemp((draftTemp ?? eventTemp(e)) + deltaTemp);
-	}
-
-	async function saveSelected() {
-		const e = selected;
-		if (!e || !homeDirty || adjusting) return;
-		adjusting = true;
+	// Button actions: the card has no inline error slot for these, so failures toast.
+	async function handleSkip(e: LogicalEvent) {
 		try {
-			if (e.recurring) {
-				// Skip the next recurrence + write a one-off at the new time/temp (atomic server-side).
-				await api.overrideNextOccurrence(e.key, draftClock!, draftTemp!);
-			} else {
-				// A one-off has no recurrence to override — move it in place, preserving its id.
-				await api.rescheduleOneOff(e.key, oneOffIso(e.job, draftClock!), draftTemp ?? undefined);
-			}
-			await reloadJobs(); // reload → reseed effect → draft goes clean
-		} catch (err) {
-			failToast("Couldn't adjust the next run. Try again.");
-			throw err; // let the guard's Save-all halt navigation when a save fails
-		} finally {
-			adjusting = false;
-		}
-	}
-
-	function discardSelected() {
-		const e = selected;
-		draftClock = e ? jobClock(e.job) : null;
-		draftTemp = e ? eventTemp(e) : null;
-	}
-
-	// Register the next-run draft while dirty so the tab-switch guard can prompt before it's
-	// lost. Tracks `homeDirty` (a boolean edge), not every tap.
-	$effect(() => {
-		if (homeDirty) {
-			registerPendingEdit({
-				id: 'home-next-run',
-				describe: draftSummary,
-				save: saveSelected,
-				discard: discardSelected
-			});
-		} else {
-			clearPendingEdit('home-next-run');
-		}
-	});
-	onDestroy(() => clearPendingEdit('home-next-run'));
-
-	// Switching the selected card while the draft is dirty would lose it — prompt first.
-	let switchModalOpen = $state(false);
-	let switchBusy = $state(false);
-	let switchError = $state<string | null>(null);
-	let pendingKey = $state<string | null>(null);
-	const switchLines = $derived(homeDirty ? [draftSummary()] : []);
-
-	function requestSelect(key: string) {
-		if (key === selectedKey) return;
-		if (homeDirty) {
-			pendingKey = key;
-			switchError = null;
-			switchModalOpen = true;
-			return;
-		}
-		selectedKey = key;
-	}
-
-	async function switchSave() {
-		switchBusy = true;
-		switchError = null;
-		try {
-			await saveSelected();
-			selectedKey = pendingKey;
-			switchModalOpen = false;
-			pendingKey = null;
-		} catch {
-			switchError = "Couldn't save the change. Try again.";
-		} finally {
-			switchBusy = false;
-		}
-	}
-
-	function switchDiscard() {
-		discardSelected();
-		selectedKey = pendingKey;
-		switchModalOpen = false;
-		pendingKey = null;
-	}
-
-	function switchStay() {
-		switchModalOpen = false;
-		pendingKey = null;
-		switchError = null;
-	}
-
-	async function skipSelected() {
-		const e = selected;
-		// Skip applies to a recurrence only; a one-off has nothing to skip to.
-		if (!e || !e.adjustable || !e.recurring || adjusting) return;
-		adjusting = true;
-		try {
-			await api.clearOverrideNext(e.key).catch(() => {}); // drop any override (also unskips)
-			await api.skipScheduledJob(e.key); // then skip the next run
+			await skipEvent(e);
 			await reloadJobs();
 		} catch {
 			failToast("Couldn't skip the next run. Try again.");
-		} finally {
-			adjusting = false;
 		}
 	}
-
-	async function resetSelected() {
-		const e = selected;
-		if (!e || !e.overridden || adjusting) return;
-		adjusting = true;
-		try {
-			await api.clearOverrideNext(e.key);
-			await reloadJobs();
-		} catch {
-			failToast("Couldn't reset to the daily default. Try again.");
-		} finally {
-			adjusting = false;
-		}
-	}
-
-	async function resumeSelected() {
-		const e = selected;
-		if (!e || !e.skipped || adjusting) return;
-		adjusting = true;
+	async function handleUnskip(e: LogicalEvent) {
 		try {
 			await api.unskipScheduledJob(e.key);
 			await reloadJobs();
 		} catch {
 			failToast("Couldn't resume the next run. Try again.");
-		} finally {
-			adjusting = false;
+		}
+	}
+	async function handleCancel(e: LogicalEvent) {
+		try {
+			await cancelEvent(e);
+			await reloadJobs();
+		} catch {
+			failToast("Couldn't remove the event. Try again.");
+		}
+	}
+	async function handleClearOverride(e: LogicalEvent) {
+		try {
+			await api.clearOverrideNext(e.key);
+			await reloadJobs();
+		} catch {
+			failToast("Couldn't reset to the daily default. Try again.");
+		}
+	}
+	async function handleMakePermanent(e: LogicalEvent) {
+		try {
+			await makePermanentEvent(e);
+			await reloadJobs();
+		} catch {
+			failToast("Couldn't make the change permanent. Try again.");
 		}
 	}
 
@@ -439,57 +238,6 @@
 		}
 	}
 </script>
-
-{#snippet repeatIcon()}
-	<svg
-		viewBox="0 0 24 24"
-		fill="none"
-		stroke="currentColor"
-		stroke-width="2"
-		stroke-linecap="round"
-		stroke-linejoin="round"
-		class="h-3.5 w-3.5 shrink-0 text-slate-500"
-		aria-hidden="true"
-	>
-		<path d="m17 2 4 4-4 4" /><path d="M3 11v-1a4 4 0 0 1 4-4h14" /><path d="m7 22-4-4 4-4" /><path
-			d="M21 13v1a4 4 0 0 1-4 4H3"
-		/>
-	</svg>
-{/snippet}
-
-{#snippet eventRow(e: LogicalEvent)}
-	<div class="flex items-start justify-between gap-3">
-		<div class="min-w-0">
-			<p
-				class="flex items-center gap-1.5 truncate font-semibold text-slate-100"
-				data-testid="next-card-title"
-			>
-				{jobTitle(e.job)}
-				{#if e.recurring}<span title="Repeats daily">{@render repeatIcon()}</span>{/if}
-			</p>
-			<p class="text-sm text-slate-400">{formatNextFire(e.nextFire)}</p>
-			{#if e.overridden}
-				<p class="mt-0.5 text-xs text-orange-300/80" data-testid="next-card-resets">
-					resets to {baseSummary(e)} daily
-				</p>
-			{:else if e.skipped}
-				<p class="mt-0.5 text-xs text-amber-300/80" data-testid="next-card-skip-info">
-					skips {skipLabel(e)}
-				</p>
-			{/if}
-		</div>
-		{#if e.overridden}
-			<span
-				class="shrink-0 rounded-full bg-orange-500/15 px-2 py-0.5 text-xs text-orange-300"
-				data-testid="next-card-adjusted">adjusted</span
-			>
-		{:else if e.skipped}
-			<span class="shrink-0 rounded-full bg-amber-500/15 px-2 py-0.5 text-xs text-amber-300"
-				>skipped</span
-			>
-		{/if}
-	</div>
-{/snippet}
 
 <section data-testid="v2-home" class="flex flex-col gap-3">
 	<!-- Temperature readout: the plain instrument-panel card, on purpose. Steve rejected
@@ -595,174 +343,26 @@
 		</div>
 	{/if}
 
-	<!-- Next up: folded events. Select a card; the control bar above acts on that card. -->
+	<!-- Next up: folded events, each card carrying its own controls (same paradigm as
+	     the Schedule tab). Guests get display-only cards. -->
 	{#if events.length > 0}
 		<section class="flex flex-col gap-2" data-testid="v2-next-up">
 			<h2 class="text-xs uppercase tracking-wide text-slate-400">Next up</h2>
-
-			{#if canSched && selected}
-				<!-- Control bar — bound to the SELECTED card by its stable key, not its position. -->
-				<div
-					class="rounded-xl border border-slate-700 bg-slate-800/50 p-3"
-					data-testid="next-controls"
-				>
-					<p class="text-xs text-slate-400">
-						{selected.recurring ? 'Adjusting just the next run' : 'Adjusting this one-time event'} ·
-						<span class="text-slate-200" data-testid="next-controls-target"
-							>{jobTitle(selected.job)} · {formatNextFire(selected.nextFire)}</span
-						>
-					</p>
-
-					{#if selected.skipped}
-						<div class="mt-2 flex items-center gap-3">
-							<span class="text-xs text-amber-300"
-								>Skipped — resumes {resumeLabel(selected.resumeDate)}</span
-							>
-							<button
-								type="button"
-								onclick={resumeSelected}
-								disabled={adjusting}
-								data-testid="next-resume"
-								class="ml-auto rounded-lg border border-amber-600/50 px-3 py-1 text-sm text-amber-300 hover:bg-amber-600/10 disabled:opacity-40"
-								>Resume next run</button
-							>
-						</div>
-					{:else if selected.adjustable}
-						<div class="mt-2 grid grid-cols-2 gap-2">
-							<div
-								class="flex items-center justify-between rounded-lg bg-slate-900/50 px-2 py-1.5"
-							>
-								<button
-									type="button"
-									aria-label="15 minutes earlier"
-									onclick={() => adjustSelected(-15, 0)}
-									disabled={adjusting}
-									class="h-7 w-7 rounded text-lg leading-none text-slate-200 hover:bg-slate-700 disabled:opacity-40"
-									>&minus;</button
-								>
-								<span class="text-xs text-slate-400"
-									>{formatClock(draftClock ?? jobClock(selected.job))}</span
-								>
-								<button
-									type="button"
-									aria-label="15 minutes later"
-									onclick={() => adjustSelected(15, 0)}
-									disabled={adjusting}
-									class="h-7 w-7 rounded text-lg leading-none text-slate-200 hover:bg-slate-700 disabled:opacity-40"
-									>+</button
-								>
-							</div>
-							<div
-								class="flex items-center justify-between rounded-lg bg-slate-900/50 px-2 py-1.5"
-							>
-								<button
-									type="button"
-									aria-label="half a degree cooler"
-									onclick={() => adjustSelected(0, -0.5)}
-									disabled={adjusting}
-									class="h-7 w-7 rounded text-lg leading-none text-slate-200 hover:bg-slate-700 disabled:opacity-40"
-									>&minus;</button
-								>
-								<span class="text-xs text-slate-400">{formatTemp(draftTemp ?? eventTemp(selected))}°F</span>
-								<button
-									type="button"
-									aria-label="half a degree warmer"
-									onclick={() => adjustSelected(0, 0.5)}
-									disabled={adjusting}
-									class="h-7 w-7 rounded text-lg leading-none text-slate-200 hover:bg-slate-700 disabled:opacity-40"
-									>+</button
-								>
-							</div>
-						</div>
-						{#if homeDirty}
-							<div class="mt-2 flex items-center gap-3 text-xs">
-								<span class="text-orange-300/80"
-									>{selected.recurring
-										? 'Unsaved — Save rewrites the schedule'
-										: 'Unsaved — Save moves this event'}</span
-								>
-								<button
-									type="button"
-									onclick={discardSelected}
-									disabled={adjusting}
-									data-testid="next-discard"
-									class="ml-auto rounded-lg px-2 py-1 text-slate-400 hover:text-slate-200 disabled:opacity-40"
-									>Discard</button
-								>
-								<button
-									type="button"
-									onclick={saveSelected}
-									disabled={adjusting}
-									data-testid="next-save"
-									class="rounded-lg bg-orange-600 px-3 py-1 font-medium text-white hover:bg-orange-500 disabled:opacity-50"
-									>{adjusting ? 'Saving…' : 'Save'}</button
-								>
-							</div>
-						{:else if selected.recurring}
-							<div class="mt-2 flex items-center gap-3 text-xs">
-								<button
-									type="button"
-									onclick={skipSelected}
-									disabled={adjusting}
-									data-testid="next-skip"
-									class="text-slate-400 hover:text-amber-300 disabled:opacity-40"
-									>Skip next run</button
-								>
-								{#if selected.overridden}
-									<button
-										type="button"
-										onclick={resetSelected}
-										disabled={adjusting}
-										data-testid="next-reset"
-										class="text-slate-400 hover:text-slate-200 disabled:opacity-40"
-										>Reset to daily</button
-									>
-								{/if}
-								<span class="ml-auto text-slate-500">default stays {baseSummary(selected)}</span>
-							</div>
-						{:else}
-							<p class="mt-2 text-xs text-slate-500" data-testid="next-oneoff-hint">
-								One-time event — moves in place when you save.
-							</p>
-						{/if}
-					{:else}
-						<p class="mt-1 text-xs text-slate-500">
-							One-time event — edit it on the Schedule tab.
-						</p>
-					{/if}
-				</div>
-			{/if}
-
-			<!-- Cards: selectable (radio-like) for schedulers, plain display for Guests. -->
-			<ul class="flex flex-col gap-2">
-				{#each events as e (e.key)}
-					<li>
-						{#if canSched}
-							<button
-								type="button"
-								onclick={() => requestSelect(e.key)}
-								aria-pressed={selectedKey === e.key}
-								data-testid="next-card"
-								data-key={e.key}
-								class="w-full rounded-xl border p-3 text-left transition-colors {selectedKey ===
-								e.key
-									? 'border-orange-500/70 bg-slate-800'
-									: 'border-slate-700 bg-slate-800/40 hover:border-slate-600'}"
-							>
-								{@render eventRow(e)}
-							</button>
-						{:else}
-							<div
-								class="rounded-xl border border-slate-700 bg-slate-800/40 p-3"
-								data-testid="next-card"
-								data-key={e.key}
-							>
-								{@render eventRow(e)}
-							</div>
-						{/if}
-					</li>
+			<div class="flex flex-col gap-2">
+				{#each events as event (event.key)}
+					<EventCard
+						{event}
+						canAdjust={canSched}
+						onOverrideNext={handleOverrideNext}
+						onReschedule={handleRescheduleOneOff}
+						onSkip={handleSkip}
+						onUnskip={handleUnskip}
+						onCancel={handleCancel}
+						onClearOverride={handleClearOverride}
+						onMakePermanent={handleMakePermanent}
+					/>
 				{/each}
-			</ul>
+			</div>
 		</section>
 	{/if}
 
@@ -811,14 +411,4 @@
 		</div>
 	{/if}
 
-	<!-- Prompt before switching the selected card abandons an unsaved next-run edit. -->
-	<UnsavedChangesModal
-		open={switchModalOpen}
-		lines={switchLines}
-		busy={switchBusy}
-		error={switchError}
-		onSave={switchSave}
-		onDiscard={switchDiscard}
-		onStay={switchStay}
-	/>
 </section>

--- a/frontend/src/routes/v2/schedule/+page.svelte
+++ b/frontend/src/routes/v2/schedule/+page.svelte
@@ -2,7 +2,8 @@
 	import { onMount } from 'svelte';
 	import { api, type ScheduledJob } from '$lib/api';
 	import { canSchedule } from '$lib/roles';
-	import { getNextOccurrence, getTimezoneOffset } from '$lib/scheduleUtils';
+	import { foldScheduledEvents, getTimezoneOffset, type LogicalEvent } from '$lib/scheduleUtils';
+	import { skipEvent, cancelEvent, makePermanentEvent } from '$lib/scheduleActions';
 	import { fetchStatus } from '$lib/stores/equipmentStatus.svelte';
 	import {
 		getTargetTempF,
@@ -17,10 +18,9 @@
 	let jobs = $state<ScheduledJob[]>([]);
 	let error = $state<string | null>(null);
 
-	// Single list, "which runs next?" first — a recurring event appears once.
-	const sortedJobs = $derived(
-		[...jobs].sort((a, b) => getNextOccurrence(a).getTime() - getNextOccurrence(b).getTime())
-	);
+	// Logical events, "which runs next?" first — a recurring event appears once, and a
+	// recurring parent + its override one-off fold into ONE adjusted card.
+	const events = $derived(foldScheduledEvents(jobs));
 
 	async function loadJobs() {
 		try {
@@ -36,28 +36,46 @@
 		loadJobs();
 	});
 
-	async function handleSkip(jobId: string) {
+	async function handleSkip(e: LogicalEvent) {
 		try {
-			await api.skipScheduledJob(jobId);
+			await skipEvent(e);
 			await loadJobs();
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to skip';
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to skip';
 		}
 	}
-	async function handleUnskip(jobId: string) {
+	async function handleUnskip(e: LogicalEvent) {
 		try {
-			await api.unskipScheduledJob(jobId);
+			await api.unskipScheduledJob(e.key);
 			await loadJobs();
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to unskip';
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to unskip';
 		}
 	}
-	async function handleCancel(jobId: string) {
+	async function handleCancel(e: LogicalEvent) {
 		try {
-			await api.cancelScheduledJob(jobId);
+			await cancelEvent(e);
 			await loadJobs();
-		} catch (e) {
-			error = e instanceof Error ? e.message : 'Failed to cancel';
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to cancel';
+		}
+	}
+	// Override management for adjusted cards (an override is created on Home, but it's
+	// managed wherever the card renders).
+	async function handleClearOverride(e: LogicalEvent) {
+		try {
+			await api.clearOverrideNext(e.key);
+			await loadJobs();
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to reset';
+		}
+	}
+	async function handleMakePermanent(e: LogicalEvent) {
+		try {
+			await makePermanentEvent(e);
+			await loadJobs();
+		} catch (err) {
+			error = err instanceof Error ? err.message : 'Failed to make permanent';
 		}
 	}
 	async function handleSaveTemp(jobId: string, tempF: number) {
@@ -249,15 +267,15 @@
 			</div>
 		{/if}
 
-		{#if sortedJobs.length === 0}
+		{#if events.length === 0}
 			<p class="text-sm text-slate-500" data-testid="schedule-empty">
 				No heating scheduled. Add a time to heat automatically.
 			</p>
 		{:else}
 			<div class="flex flex-col gap-2">
-				{#each sortedJobs as job (job.jobId)}
+				{#each events as event (event.key)}
 					<EventCard
-						{job}
+						{event}
 						canAdjust={allowed}
 						onSkip={handleSkip}
 						onUnskip={handleUnskip}
@@ -265,6 +283,8 @@
 						onSaveTemp={handleSaveTemp}
 						onReschedule={handleReschedule}
 						onRescheduleRecurring={handleRescheduleRecurring}
+						onClearOverride={handleClearOverride}
+						onMakePermanent={handleMakePermanent}
 					/>
 				{/each}
 			</div>


### PR DESCRIPTION
## Summary
Deploys the v2 schedule refactor along with the temperature-step bug fix.

- **Fix (reported bug):** the ± buttons for target temp now step by **0.25°F** instead of 0.5°F — on both the Home target dial and the scheduled-event card steppers.
- Extract `scheduleActions.ts` (reschedule/override helpers) with unit coverage.
- Rework `EventCard` so one-off and recurring heat events render the same ± steppers (card parity), staging edits locally until Save.
- Slim `v2/+page.svelte` and `v2/schedule/+page.svelte` onto the shared helpers.
- Add `scheduleUtils` helpers (`formatTemp`, `shiftHHMM`, …) with tests.
- Doc updates in `docs/redesign/`.

## Testing
`./scripts/test.sh` — all suites pass: backend PHPUnit, frontend Vitest (285), esp32 Unity, Playwright E2E (139 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)