### PR TITLE
Password reset in user management; delete+recreate revokes JWTs; back-link fix

### DIFF
--- a/backend/src/Services/AuthService.php
+++ b/backend/src/Services/AuthService.php
@@ -66,6 +66,22 @@ class AuthService
             throw new \RuntimeException('Invalid token: role mismatch');
         }
 
+        // The token must postdate the user row. This makes delete-then-recreate
+        // a real revocation: tokens minted for the deleted account carry an iat
+        // older than the recreated row's created_at and stay dead forever.
+        // (Password changes deliberately do NOT revoke tokens — delete/recreate
+        // is this app's revocation mechanism.) Rows without created_at (legacy)
+        // can't anchor the check and are accepted.
+        $createdAt = isset($user['created_at']) ? strtotime($user['created_at']) : false;
+        if ($createdAt !== false) {
+            if (!isset($claims['iat'])) {
+                throw new \RuntimeException('Invalid token: missing iat');
+            }
+            if ((int) $claims['iat'] < $createdAt) {
+                throw new \RuntimeException('Invalid token: predates the user account');
+            }
+        }
+
         return $claims;
     }
 }

--- a/backend/tests/Services/AuthServiceTest.php
+++ b/backend/tests/Services/AuthServiceTest.php
@@ -188,14 +188,18 @@ class AuthServiceTest extends TestCase
 
     // --- Layer 1: DB-backed token validation ---
 
-    private function mintToken(string $sub, string $role): string
+    private function mintToken(string $sub, string $role, ?int $iat = null): string
     {
-        return JWT::encode([
-            'iat' => time(),
+        $payload = [
             'exp' => time() + 3600,
             'sub' => $sub,
             'role' => $role,
-        ], $this->config['JWT_SECRET'], 'HS256');
+        ];
+        if ($iat !== -1) {
+            $payload['iat'] = $iat ?? time();
+        }
+
+        return JWT::encode($payload, $this->config['JWT_SECRET'], 'HS256');
     }
 
     public function testValidateTokenRejectsUnknownSubject(): void
@@ -247,5 +251,115 @@ class AuthServiceTest extends TestCase
 
         $this->assertSame('homeassistant', $claims['sub']);
         $this->assertSame('readonly', $claims['role']);
+    }
+
+    // --- Layer 2: tokens must postdate the user row ---
+    //
+    // Deleting a user must revoke its tokens PERMANENTLY, even if an account with
+    // the same name is created later: the recreated row has a newer created_at
+    // than the old token's iat. (Password changes deliberately do NOT revoke —
+    // delete/recreate is this app's revocation mechanism.)
+
+    public function testValidateTokenRejectsTokenPredatingUserCreation(): void
+    {
+        // Token minted an hour before the user row existed → a leftover token
+        // from a deleted-then-recreated account. Must be rejected.
+        $mock = $this->createMock(UserRepositoryInterface::class);
+        $mock->method('findByUsername')->willReturn([
+            'username' => 'steve',
+            'role' => 'user',
+            'password_hash' => 'hashed',
+            'created_at' => date('c'),
+        ]);
+        $authService = new AuthService($mock, $this->config);
+
+        $token = $this->mintToken('steve', 'user', time() - 3600);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('predates');
+        $authService->validateToken($token);
+    }
+
+    public function testValidateTokenAcceptsTokenMintedSameSecondAsUserCreation(): void
+    {
+        // Create-user-then-login can happen within one second; must not reject.
+        $now = time();
+        $mock = $this->createMock(UserRepositoryInterface::class);
+        $mock->method('findByUsername')->willReturn([
+            'username' => 'steve',
+            'role' => 'user',
+            'password_hash' => 'hashed',
+            'created_at' => date('c', $now),
+        ]);
+        $authService = new AuthService($mock, $this->config);
+
+        $token = $this->mintToken('steve', 'user', $now);
+        $claims = $authService->validateToken($token);
+
+        $this->assertSame('steve', $claims['sub']);
+    }
+
+    public function testValidateTokenRejectsTokenWithoutIat(): void
+    {
+        // Every token this system mints (login, mint-jwt.php, generate-cron-jwt.php)
+        // carries iat; a token without one has unknown provenance → reject.
+        $mock = $this->createMock(UserRepositoryInterface::class);
+        $mock->method('findByUsername')->willReturn([
+            'username' => 'steve',
+            'role' => 'user',
+            'password_hash' => 'hashed',
+            'created_at' => date('c', time() - 3600),
+        ]);
+        $authService = new AuthService($mock, $this->config);
+
+        $token = $this->mintToken('steve', 'user', -1); // -1 → omit iat
+
+        $this->expectException(\RuntimeException::class);
+        $authService->validateToken($token);
+    }
+
+    public function testValidateTokenAcceptsWhenUserRowLacksCreatedAt(): void
+    {
+        // Legacy rows without created_at can't anchor the check; accept rather
+        // than lock those accounts out.
+        $mock = $this->createMock(UserRepositoryInterface::class);
+        $mock->method('findByUsername')->willReturn([
+            'username' => 'legacy',
+            'role' => 'user',
+            'password_hash' => 'hashed',
+        ]);
+        $authService = new AuthService($mock, $this->config);
+
+        $token = $this->mintToken('legacy', 'user', time() - 999999);
+        $claims = $authService->validateToken($token);
+
+        $this->assertSame('legacy', $claims['sub']);
+    }
+
+    public function testDeleteAndRecreateUserInvalidatesOldTokens(): void
+    {
+        // End-to-end with the real JSON repository: login → delete → recreate
+        // (same name, same role, same password) → the old token must be dead,
+        // and a fresh login must work.
+        $repo = new \HotTub\Services\JsonUserRepository($this->usersFile);
+        $authService = new AuthService($repo, $this->config);
+
+        $repo->create('forgetful', 'oldpass', 'user');
+        $oldToken = $authService->login('forgetful', 'oldpass');
+        $this->assertSame('forgetful', $authService->validateToken($oldToken)['sub']);
+
+        $repo->delete('forgetful');
+        sleep(1); // created_at has second resolution; make the recreation strictly newer
+        $repo->create('forgetful', 'oldpass', 'user');
+
+        try {
+            $authService->validateToken($oldToken);
+            $this->fail('Expected old token to be rejected after delete + recreate');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('predates', $e->getMessage());
+        }
+
+        $newToken = $authService->login('forgetful', 'oldpass');
+        $this->assertSame('forgetful', $authService->validateToken($newToken)['sub']);
     }
 }

--- a/frontend/e2e/user-management.spec.ts
+++ b/frontend/e2e/user-management.spec.ts
@@ -129,6 +129,60 @@ test.describe('User Management', () => {
 		await expect(page.locator(`li:has-text("${uniqueUsername}")`)).not.toBeVisible({ timeout: 5000 });
 	});
 
+	test('admin can reset a user password', async ({ page, request }) => {
+		// Navigate to users page
+		await page.click('a:has-text("Users")', { force: true });
+		await expect(page.getByRole('heading', { name: 'USER MANAGEMENT' })).toBeVisible({
+			timeout: 10000
+		});
+
+		// Create a user whose password we'll reset
+		const uniqueUsername = `testuser_pwreset_${Date.now()}`;
+		await page.fill('#username', uniqueUsername);
+		await page.fill('#password', 'originalpass123');
+		await page.click('button:has-text("Create User")', { force: true });
+		await expect(page.locator('text=User Created Successfully')).toBeVisible({ timeout: 10000 });
+		await page.click('button:has-text("Done")', { force: true });
+
+		// Open the reset-password form for that user
+		await page
+			.locator(`li:has-text("${uniqueUsername}")`)
+			.locator('button:has-text("Reset")')
+			.click({ force: true });
+
+		// Enter the new password and confirm
+		await page.fill('#reset-password', 'newpass456');
+		await page.click('button:has-text("Reset Password")', { force: true });
+
+		// The credentials modal shows the new password for sharing
+		await expect(page.locator('text=Password Reset Successfully')).toBeVisible({ timeout: 10000 });
+		await expect(page.locator(`code:has-text("${uniqueUsername}")`)).toBeVisible();
+		await expect(page.locator('code:has-text("newpass456")')).toBeVisible();
+		await page.click('button:has-text("Done")', { force: true });
+
+		// The old password no longer works; the new one does. The `request` fixture
+		// has its own cookie jar, so these logins don't clobber the admin session.
+		const oldLogin = await request.post('/tub/backend/public/api/auth/login', {
+			data: { username: uniqueUsername, password: 'originalpass123' }
+		});
+		expect(oldLogin.status()).toBe(401);
+
+		const newLogin = await request.post('/tub/backend/public/api/auth/login', {
+			data: { username: uniqueUsername, password: 'newpass456' }
+		});
+		expect(newLogin.ok()).toBe(true);
+
+		// Clean up
+		page.on('dialog', (dialog) => dialog.accept());
+		await page
+			.locator(`li:has-text("${uniqueUsername}")`)
+			.locator('button:has-text("Delete")')
+			.click({ force: true });
+		await expect(page.locator(`li:has-text("${uniqueUsername}")`)).not.toBeVisible({
+			timeout: 5000
+		});
+	});
+
 	test('admin cannot delete themselves', async ({ page }) => {
 		// Navigate to users page
 		await page.click('a:has-text("Users")', { force: true });
@@ -152,8 +206,8 @@ test.describe('User Management', () => {
 		// Click back link
 		await page.click('a:has-text("Back to Controls")', { force: true });
 
-		// Should be back on main page
-		await expect(page.getByRole('heading', { name: 'HOT TUB CONTROL' })).toBeVisible({
+		// Should land on the default interface (v2 Home at the root), not /v1
+		await expect(page.getByTestId('v2-home')).toBeVisible({
 			timeout: 10000
 		});
 	});

--- a/frontend/src/routes/v1/users/+page.svelte
+++ b/frontend/src/routes/v1/users/+page.svelte
@@ -16,10 +16,16 @@
 	let newRole = $state<'user' | 'admin' | 'basic' | 'readonly'>('user');
 	let isCreating = $state(false);
 
-	// Credential display modal
+	// Credential display modal (shown after create and after password reset)
 	let showCredentials = $state(false);
 	let createdCredentials = $state<CreateUserResponse | null>(null);
+	let credentialsTitle = $state('User Created Successfully');
 	let loginUrl = $state('');
+
+	// Password reset form state
+	let resetUsername = $state<string | null>(null);
+	let resetPassword = $state('');
+	let isResetting = $state(false);
 
 	// Refresh button tooltip state
 	let showRefreshTooltip = $state(false);
@@ -62,6 +68,7 @@
 			error = null;
 			const result = await api.createUser(newUsername, newPassword, newRole);
 			createdCredentials = result;
+			credentialsTitle = 'User Created Successfully';
 			// Compute login URL (window.location.origin + base path + /login)
 			loginUrl = window.location.origin + base + '/login';
 			showCredentials = true;
@@ -77,6 +84,48 @@
 			}
 		} finally {
 			isCreating = false;
+		}
+	}
+
+	function openReset(username: string) {
+		resetUsername = username;
+		resetPassword = '';
+		error = null;
+	}
+
+	function cancelReset() {
+		resetUsername = null;
+		resetPassword = '';
+	}
+
+	async function resetUserPassword() {
+		if (!resetUsername || !resetPassword) {
+			error = 'Password is required';
+			return;
+		}
+
+		try {
+			isResetting = true;
+			error = null;
+			await api.updateUserPassword(resetUsername, resetPassword);
+			// Reuse the credentials modal so the new password can be shared,
+			// same as after creating a user.
+			createdCredentials = {
+				username: resetUsername,
+				password: resetPassword,
+				role: '',
+				message: ''
+			};
+			credentialsTitle = 'Password Reset Successfully';
+			loginUrl = window.location.origin + base + '/login';
+			showCredentials = true;
+			cancelReset();
+		} catch (e) {
+			if (e instanceof Error) {
+				error = e.message;
+			}
+		} finally {
+			isResetting = false;
 		}
 	}
 
@@ -139,7 +188,7 @@
 	<header class="mb-6 flex flex-wrap items-center justify-between gap-x-4 gap-y-1">
 		<h1 class="text-xl font-bold text-slate-100 tracking-wide">USER MANAGEMENT</h1>
 		<div class="flex items-center gap-4">
-			<a href="{base}/v1/" class="text-slate-400 hover:text-slate-200 text-sm underline">
+			<a href="{base}/" class="text-slate-400 hover:text-slate-200 text-sm underline">
 				Back to Controls
 			</a>
 			{#if data.user}
@@ -246,22 +295,65 @@
 				{:else}
 					<ul class="space-y-2">
 						{#each users as user}
-							<li class="flex items-center justify-between bg-slate-700/50 rounded p-3">
-								<div>
-									<span class="text-slate-100 font-medium">{user.username}</span>
-									<span class="ml-2 px-2 py-0.5 text-xs rounded {user.role === 'admin' ? 'bg-amber-500/20 text-amber-400' : user.role === 'basic' ? 'bg-cyan-500/20 text-cyan-400' : user.role === 'readonly' ? 'bg-violet-500/20 text-violet-400' : 'bg-slate-600 text-slate-300'}">
-										{user.role}
-									</span>
+							<li class="bg-slate-700/50 rounded p-3">
+								<div class="flex items-center justify-between">
+									<div>
+										<span class="text-slate-100 font-medium">{user.username}</span>
+										<span class="ml-2 px-2 py-0.5 text-xs rounded {user.role === 'admin' ? 'bg-amber-500/20 text-amber-400' : user.role === 'basic' ? 'bg-cyan-500/20 text-cyan-400' : user.role === 'readonly' ? 'bg-violet-500/20 text-violet-400' : 'bg-slate-600 text-slate-300'}">
+											{user.role}
+										</span>
+									</div>
+									<div class="flex items-center gap-3">
+										<button
+											onclick={() => openReset(user.username)}
+											class="text-cyan-400 hover:text-cyan-300 text-sm"
+										>
+											Reset
+										</button>
+										{#if user.username !== data.user?.username}
+											<button
+												onclick={() => deleteUser(user.username)}
+												class="text-red-400 hover:text-red-300 text-sm"
+											>
+												Delete
+											</button>
+										{:else}
+											<span class="text-slate-500 text-sm">(you)</span>
+										{/if}
+									</div>
 								</div>
-								{#if user.username !== data.user?.username}
-									<button
-										onclick={() => deleteUser(user.username)}
-										class="text-red-400 hover:text-red-300 text-sm"
+								{#if resetUsername === user.username}
+									<form
+										onsubmit={(e) => { e.preventDefault(); resetUserPassword(); }}
+										class="mt-3 flex items-end gap-2"
 									>
-										Delete
-									</button>
-								{:else}
-									<span class="text-slate-500 text-sm">(you)</span>
+										<div class="flex-1">
+											<label for="reset-password" class="block text-sm text-slate-400 mb-1">
+												New password
+											</label>
+											<input
+												type="text"
+												id="reset-password"
+												bind:value={resetPassword}
+												class="w-full px-3 py-2 bg-slate-700 border border-slate-600 rounded text-slate-100 focus:outline-none focus:border-cyan-500"
+												placeholder="Enter new password"
+											/>
+										</div>
+										<button
+											type="submit"
+											disabled={isResetting}
+											class="py-2 px-3 bg-cyan-600 hover:bg-cyan-500 disabled:bg-slate-600 text-white rounded text-sm font-medium transition-colors whitespace-nowrap"
+										>
+											{isResetting ? 'Resetting...' : 'Reset Password'}
+										</button>
+										<button
+											type="button"
+											onclick={cancelReset}
+											class="py-2 px-3 bg-slate-700 hover:bg-slate-600 text-slate-200 rounded text-sm font-medium transition-colors"
+										>
+											Cancel
+										</button>
+									</form>
 								{/if}
 							</li>
 						{/each}
@@ -276,7 +368,7 @@
 {#if showCredentials && createdCredentials}
 	<div class="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
 		<div class="bg-slate-800 rounded-lg p-6 max-w-md w-full border border-slate-700">
-			<h2 class="text-lg font-semibold text-slate-100 mb-4">User Created Successfully</h2>
+			<h2 class="text-lg font-semibold text-slate-100 mb-4">{credentialsTitle}</h2>
 			<p class="text-slate-400 text-sm mb-4">Share these credentials with the user:</p>
 
 			<div class="bg-slate-900 rounded p-4 mb-4 space-y-2">


### PR DESCRIPTION
## Summary
- Users page: per-user **Reset** button opens an inline new-password form; the new credentials are shown in the existing share-credentials modal. (Backend endpoint and API client already existed — this adds the UI.)
- Password changes intentionally do **not** invalidate JWTs. Revocation is delete/recreate: `AuthService::validateToken` now requires the token's `iat` to postdate the user row's `created_at`, so deleting a user permanently kills its tokens even if an account with the same name is created later.
- Fixed the users page "Back to Controls" link to go to the root (v2 default) instead of `/v1` — the only leftover wrong-default link from the mount swap.

## Compatibility notes
- All minting paths (login, `mint-jwt.php`, `generate-cron-jwt.php`) set `iat`, and `CRON_JWT` is re-minted on every deploy, so existing production tokens remain valid (they were all minted after their user rows were created).
- Legacy user rows without `created_at` skip the new check rather than locking out.

## Testing
TDD red/green: 5 new AuthService tests (including a real-repository delete→recreate integration test) and a new E2E for the reset flow (old password rejected with 401, new password logs in). Full local suite green via `./scripts/test.sh`: backend PHPUnit (999), frontend Vitest, ESP32 Unity, Playwright E2E (140 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)