### PR TITLE
Per-job ambient heat target, shown on the schedule card

### DIFF
--- a/backend/public/index.php
+++ b/backend/public/index.php
@@ -254,7 +254,7 @@ $requireWrite = fn() => $authMiddleware->requireWrite($headers, $cookies);
 $router = new Router();
 
 // Public routes
-$router->get('/api/health', function() use ($equipmentController, $blindsController, $heatTargetSettingsService, $stallEventFile) {
+$router->get('/api/health', function() use ($equipmentController, $blindsController, $heatTargetSettingsService, $stallEventFile, $targetTemperatureService, $authMiddleware, $headers, $cookies) {
     $response = $equipmentController->health();
     $response['body']['blindsEnabled'] = $blindsController->isEnabled();
     $response['body']['heatTargetSettings'] = [
@@ -267,6 +267,15 @@ $router->get('/api/health', function() use ($equipmentController, $blindsControl
         'dynamic_mode' => $heatTargetSettingsService->isDynamicMode(),
         'calibration_points' => $heatTargetSettingsService->getCalibrationPoints(),
     ];
+    // The card's live "what would the curve pick right now" projection. /api/health is
+    // public, and this carries an outdoor-air reading plus a sensor-offline signal —
+    // telemetry the rest of the API keeps behind auth — so it's attached only for a
+    // recognised caller. A soft check: authenticate() returns null instead of an error
+    // envelope, so anonymous callers still get a normal health response.
+    if ($authMiddleware->authenticate($headers, $cookies) !== null) {
+        $response['body']['heatTargetSettings']['dynamic_preview'] =
+            $targetTemperatureService->previewDynamicTarget();
+    }
     // Include last stall event if it exists
     if (file_exists($stallEventFile)) {
         $stallData = json_decode(file_get_contents($stallEventFile), true);
@@ -319,6 +328,8 @@ $router->post('/api/schedule', fn() => handleScheduleCreate($scheduleController)
 $router->get('/api/schedule', fn() => $scheduleController->list(), $requireAuth);
 $router->delete('/api/schedule/{id}', fn($params) => $scheduleController->cancel($params['id']), $requireWrite);
 $router->put('/api/schedule/{id}/target-temp', fn($params) => handleScheduleUpdateTargetTemp($scheduleController, $params['id']), $requireWrite);
+// Switch one job between a fixed temperature and the ambient-matched curve.
+$router->put('/api/schedule/{id}/heat-mode', fn($params) => handleScheduleUpdateHeatMode($scheduleController, $params['id']), $requireWrite);
 // Move a one-off to a new time/temp in place (atomic; preserves the job id).
 $router->put('/api/schedule/{id}/reschedule', fn($params) => handleScheduleReschedule($scheduleController, $params['id']), $requireWrite);
 $router->post('/api/schedule/{id}/skip', fn($params) => $scheduleController->skip($params['id']), $requireWrite);
@@ -506,6 +517,12 @@ function handleScheduleUpdateTargetTemp(ScheduleController $controller, string $
 {
     $input = json_decode(file_get_contents('php://input'), true) ?? [];
     return $controller->updateTargetTemp($jobId, $input);
+}
+
+function handleScheduleUpdateHeatMode(ScheduleController $controller, string $jobId): array
+{
+    $input = json_decode(file_get_contents('php://input'), true) ?? [];
+    return $controller->updateHeatMode($jobId, $input);
 }
 
 function handleScheduleReschedule(ScheduleController $controller, string $jobId): array

--- a/backend/src/Controllers/ScheduleController.php
+++ b/backend/src/Controllers/ScheduleController.php
@@ -54,6 +54,13 @@ class ScheduleController
                 ];
             }
             $params['target_temp_f'] = (float) $data['target_temp_f'];
+            // Stamp the heat mode at creation. The global dynamic_mode is only the
+            // DEFAULT for new jobs — a job keeps the configuration it was built with,
+            // so flipping the household default later leaves this job alone.
+            // Kept flat: cron-runner.sh's params regex can't survive a nested object.
+            $params['dynamic'] = array_key_exists('dynamic', $data)
+                ? (bool) $data['dynamic']
+                : ($this->settings?->isDynamicMode() ?? false);
         }
 
         try {
@@ -208,6 +215,39 @@ class ScheduleController
     }
 
     /**
+     * PUT /api/schedule/{id}/heat-mode - Switch a heat-to-target job between a fixed
+     * temperature and the ambient-matched curve.
+     *
+     * @param string $jobId The job ID to update
+     * @param array{dynamic?: bool} $data Request body
+     * @return array{status: int, body: array}
+     */
+    public function updateHeatMode(string $jobId, array $data): array
+    {
+        if (!array_key_exists('dynamic', $data) || !is_bool($data['dynamic'])) {
+            return [
+                'status' => 400,
+                'body' => ['error' => 'Missing or invalid required field: dynamic (boolean)'],
+            ];
+        }
+
+        try {
+            $updated = $this->scheduler->updateJobDynamic($jobId, $data['dynamic']);
+
+            return [
+                'status' => 200,
+                'body' => $updated,
+            ];
+        } catch (InvalidArgumentException $e) {
+            $status = str_contains(strtolower($e->getMessage()), 'not found') ? 404 : 400;
+            return [
+                'status' => $status,
+                'body' => ['error' => $e->getMessage()],
+            ];
+        }
+    }
+
+    /**
      * PUT /api/schedule/{id}/reschedule — move a job to a new time (and optional temp),
      * atomically and in place (the job id is preserved), so a heat is never dropped by
      * a failed recreate.
@@ -342,6 +382,12 @@ class ScheduleController
 
             $timezone = $parent['params']['timezone'] ?? $parent['timezone'] ?? $this->settings?->getTimezone();
             $overrideParams = ['target_temp_f' => $newTempF, 'override_of' => $jobId];
+            // These params are rebuilt from scratch, so the parent's heat mode has to be
+            // carried across explicitly — otherwise an override of an ambient-matched
+            // daily job silently comes out fixed.
+            if (array_key_exists('dynamic', $parent['params'] ?? [])) {
+                $overrideParams['dynamic'] = (bool) $parent['params']['dynamic'];
+            }
 
             if (isset($parent['params']['ready_by_time']) && $this->dtdtService !== null) {
                 $job = $this->dtdtService->createReadyByOverride($overrideDate, $newTime, $overrideParams, $timezone);

--- a/backend/src/Controllers/TargetTemperatureController.php
+++ b/backend/src/Controllers/TargetTemperatureController.php
@@ -30,8 +30,15 @@ class TargetTemperatureController
 
         $targetTempF = (float) $input['target_temp_f'];
 
+        // Tri-state: present → this heat's own mode, absent → inherit the global default.
+        // array_key_exists, not isset — isset() is false for a null value and would
+        // collapse an explicit null into "fixed".
+        $dynamic = array_key_exists('dynamic', $input) && $input['dynamic'] !== null
+            ? (bool) $input['dynamic']
+            : null;
+
         try {
-            $result = $this->service->start($targetTempF);
+            $result = $this->service->start($targetTempF, $dynamic);
         } catch (\InvalidArgumentException $e) {
             return [
                 'status' => 400,

--- a/backend/src/Services/DtdtService.php
+++ b/backend/src/Services/DtdtService.php
@@ -149,6 +149,11 @@ class DtdtService
         $readyByTime = $params['ready_by_time'] ?? null;
         $targetTempF = (float) ($params['target_temp_f'] ?? 103.0);
         $timezone = $params['timezone'] ?? null;
+        // This job's own heat mode. Absent (a job predating per-job mode) stays null so
+        // the heat still inherits the global default when it starts.
+        $dynamic = array_key_exists('dynamic', $params) && $params['dynamic'] !== null
+            ? (bool) $params['dynamic']
+            : null;
 
         if ($readyByTime === null) {
             return ['error' => 'Missing ready_by_time parameter'];
@@ -168,15 +173,26 @@ class DtdtService
 
         // Fallback: no data → start immediately (conservative)
         if ($waterTempF === null || $chars === null) {
-            return $this->startImmediately($targetTempF, 'No temperature data or heating characteristics');
+            return $this->startImmediately(
+                $targetTempF,
+                'No temperature data or heating characteristics',
+                $dynamic
+            );
         }
 
+        // All the timing below must aim at the temperature this heat will ACTUALLY
+        // target. For an ambient-matched job that's the curve's answer, which on a cold
+        // morning can sit well above the stored temp — projecting against the stored one
+        // left the tub short of its ready-by time. The stored $targetTempF stays the
+        // fallback written into the precision job's params; only the math moves.
+        $projectedTargetF = $this->resolveProjectedTarget($targetTempF, $dynamic);
+
         // Already at target → nothing to do
-        if ($waterTempF >= $targetTempF) {
+        if ($waterTempF >= $projectedTargetF) {
             return [
                 'status' => 'already_at_target',
                 'water_temp_f' => $waterTempF,
-                'target_temp_f' => $targetTempF,
+                'target_temp_f' => $projectedTargetF,
             ];
         }
 
@@ -191,46 +207,78 @@ class DtdtService
         }
 
         // If projected temp stays above target → no heating needed
-        if ($projectedTempF >= $targetTempF) {
+        if ($projectedTempF >= $projectedTargetF) {
             return [
                 'status' => 'stays_warm',
                 'water_temp_f' => $waterTempF,
                 'projected_temp_f' => round($projectedTempF, 1),
-                'target_temp_f' => $targetTempF,
+                'target_temp_f' => $projectedTargetF,
             ];
         }
 
         // Calculate heat time needed
         $velocity = $chars['heating_velocity_f_per_min'];
         $lag = $chars['startup_lag_minutes'] ?? 0;
-        $heatMinutes = ($targetTempF - $projectedTempF) / $velocity + $lag;
+        $heatMinutes = ($projectedTargetF - $projectedTempF) / $velocity + $lag;
         $startTimestamp = $readyByTimestamp - (int) ceil($heatMinutes * 60);
 
         // If start time is now or in the past → start immediately
         if ($startTimestamp <= $now) {
-            return $this->startImmediately($targetTempF, 'Calculated start time is now or past');
+            return $this->startImmediately(
+                $targetTempF,
+                'Calculated start time is now or past',
+                $dynamic
+            );
         }
 
         // Schedule a precision one-off cron at the calculated start time
         $startDateTime = new \DateTime('@' . $startTimestamp);
         $startDateTime->setTimezone(new \DateTimeZone('UTC'));
 
+        // The one-off stores the STATIC temp plus the mode — the curve is re-read when
+        // the heat actually starts, not frozen here at wake-up.
+        $precisionParams = ['target_temp_f' => $targetTempF];
+        if ($dynamic !== null) {
+            $precisionParams['dynamic'] = $dynamic;
+        }
+
         $result = $this->schedulerService->scheduleJob(
             'heat-to-target',
             $startDateTime->format(\DateTime::ATOM),
             recurring: false,
-            params: ['target_temp_f' => $targetTempF]
+            params: $precisionParams
         );
 
         return [
             'status' => 'precision_scheduled',
             'water_temp_f' => $waterTempF,
             'projected_temp_f' => round($projectedTempF, 1),
-            'target_temp_f' => $targetTempF,
+            'target_temp_f' => $projectedTargetF,
             'heat_minutes' => round($heatMinutes, 1),
             'start_time' => $startDateTime->format(\DateTime::ATOM),
             'jobId' => $result['jobId'],
         ];
+    }
+
+    /**
+     * The temperature this heat will actually aim at, for lead-time math only.
+     *
+     * Only an explicitly ambient-matched job re-resolves; a job with no stored mode
+     * ($dynamic === null) keeps the pre-per-job-mode behaviour, and a sensor-unavailable
+     * projection falls back to the stored temp rather than dropping the heat.
+     */
+    private function resolveProjectedTarget(float $staticTargetF, ?bool $dynamic): float
+    {
+        if ($dynamic !== true) {
+            return $staticTargetF;
+        }
+
+        $preview = $this->targetTemperatureService?->previewDynamicTarget();
+        if ($preview === null || $preview['fallback']) {
+            return $staticTargetF;
+        }
+
+        return (float) $preview['computed_target_f'];
     }
 
     /**
@@ -360,11 +408,13 @@ class DtdtService
 
     /**
      * Start heating immediately by calling TargetTemperatureService.
+     *
+     * @param bool|null $dynamic The job's heat mode; null inherits the global default
      */
-    private function startImmediately(float $targetTempF, string $reason): array
+    private function startImmediately(float $targetTempF, string $reason, ?bool $dynamic = null): array
     {
         if ($this->targetTemperatureService !== null) {
-            $this->targetTemperatureService->start($targetTempF);
+            $this->targetTemperatureService->start($targetTempF, $dynamic);
         }
 
         return [

--- a/backend/src/Services/SchedulerService.php
+++ b/backend/src/Services/SchedulerService.php
@@ -615,6 +615,39 @@ class SchedulerService
     }
 
     /**
+     * Switch a heat-to-target job between a fixed temperature and the ambient curve.
+     *
+     * array_merge preserves sibling params (target_temp_f, ready_by_time, override_of,
+     * timezone), which is also why temp edits and reschedules carry `dynamic` through
+     * untouched without any change of their own.
+     *
+     * @param string $jobId The job ID to update
+     * @param bool $dynamic True to follow the ambient curve, false for the stored temp
+     * @return array Updated job data
+     * @throws InvalidArgumentException If the job is missing or not heat-to-target
+     */
+    public function updateJobDynamic(string $jobId, bool $dynamic): array
+    {
+        $jobFile = $this->jobsDir . '/' . $jobId . '.json';
+
+        if (!file_exists($jobFile)) {
+            throw new InvalidArgumentException('Job not found: ' . $jobId);
+        }
+
+        $jobData = json_decode(file_get_contents($jobFile), true);
+
+        if (($jobData['action'] ?? '') !== 'heat-to-target') {
+            throw new InvalidArgumentException('Can only set heat mode for heat-to-target jobs');
+        }
+
+        $jobData['params'] = array_merge($jobData['params'] ?? [], ['dynamic' => $dynamic]);
+
+        file_put_contents($jobFile, json_encode($jobData, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $jobData;
+    }
+
+    /**
      * Reschedule a one-off job to a new time (and optionally a new target temp),
      * preserving its job id and re-registering its cron entry at the new time.
      *

--- a/backend/src/Services/TargetTemperatureService.php
+++ b/backend/src/Services/TargetTemperatureService.php
@@ -102,10 +102,14 @@ class TargetTemperatureService
      * Acquires lock, checks for active session, saves state, releases lock,
      * then calls checkAndAdjust() (which acquires its own lock).
      *
+     * @param float $targetTempF The fixed target, and the fallback if the ambient sensor is down
+     * @param bool|null $dynamic Per-heat mode override: true → follow the ambient curve,
+     *                           false → use $targetTempF as-is, null → inherit the global
+     *                           default (jobs created before per-job mode existed)
      * @return array Result of initial checkAndAdjust (includes heater state, cron scheduled, etc.)
      * @throws \RuntimeException If a heating session is already active
      */
-    public function start(float $targetTempF): array
+    public function start(float $targetTempF, ?bool $dynamic = null): array
     {
         if ($targetTempF < self::MIN_TARGET_TEMP_F || $targetTempF > self::MAX_TARGET_TEMP_F) {
             throw new \InvalidArgumentException(
@@ -124,8 +128,8 @@ class TargetTemperatureService
                 throw new \RuntimeException('Heat-to-target is already active');
             }
 
-            // Resolve dynamic target if enabled
-            $dynamicResult = $this->resolveDynamicTarget($targetTempF);
+            // Resolve dynamic target if enabled (per-job override, else the global default)
+            $dynamicResult = $this->resolveDynamicTarget($targetTempF, $dynamic);
             $effectiveTargetF = $dynamicResult['target_f'];
 
             $state = [
@@ -933,22 +937,89 @@ class TargetTemperatureService
     }
 
     /**
+     * What the ambient curve would pick right now — for showing a projection on a
+     * schedule card.
+     *
+     * Deliberately NOT gated on the global `dynamic_mode`, nor on `enabled`. Both are
+     * household-level switches, and neither tells you what an individual job does: a
+     * single job can follow the curve while the default is off (the common setup), and
+     * scheduled heat-to-target jobs outlive the Heat-now toggle. Gating on either would
+     * blank the projection on exactly the cards that need it. The cost is one ESP32
+     * reading — the same file /api/temperature already polls.
+     *
+     * @return array{ambient_temp_f: ?float, computed_target_f: float, segment?: string,
+     *               clamped: bool, fallback: bool, fallback_reason?: string}|null
+     */
+    public function previewDynamicTarget(): ?array
+    {
+        if ($this->heatTargetSettings === null) {
+            return null;
+        }
+
+        return $this->computeCurveTarget($this->heatTargetSettings->getTargetTempF());
+    }
+
+    /**
+     * The one ambient read + one DynamicTargetCalculator call site in the codebase.
+     *
+     * Shared by previewDynamicTarget() (what a card shows) and resolveDynamicTarget()
+     * (what a heat actually starts with), so the two can never drift apart.
+     *
+     * @param float $fallbackTargetF Target used when the ambient sensor is unreadable
+     * @return array{ambient_temp_f: ?float, computed_target_f: float, segment?: string,
+     *               clamped: bool, fallback: bool, fallback_reason?: string}
+     */
+    private function computeCurveTarget(float $fallbackTargetF): array
+    {
+        $ambientTempF = $this->getCalibratedAmbientTempF();
+
+        if ($ambientTempF === null) {
+            return [
+                'ambient_temp_f' => null,
+                'computed_target_f' => $fallbackTargetF,
+                'clamped' => false,
+                'fallback' => true,
+                'fallback_reason' => 'ambient_sensor_unavailable',
+            ];
+        }
+
+        $result = DynamicTargetCalculator::calculate(
+            $ambientTempF,
+            $this->heatTargetSettings?->getCalibrationPoints() ?? []
+        );
+
+        return [
+            // Full precision — round for display only.
+            'ambient_temp_f' => $ambientTempF,
+            'computed_target_f' => $result['target_f'],
+            'segment' => $result['segment'],
+            'clamped' => $result['clamped'],
+            'fallback' => false,
+        ];
+    }
+
+    /**
      * Resolve the effective target temperature, applying dynamic calculation if enabled.
      *
      * @param float $staticTargetF The static target temperature passed by the caller
+     * @param bool|null $dynamicOverride Per-job mode; null inherits the global default
      * @return array{target_f: float, dynamic_target_info: ?array}
      */
-    private function resolveDynamicTarget(float $staticTargetF): array
+    private function resolveDynamicTarget(float $staticTargetF, ?bool $dynamicOverride = null): array
     {
-        if ($this->heatTargetSettings === null || !$this->heatTargetSettings->isDynamicMode()) {
+        $useDynamic = $dynamicOverride ?? ($this->heatTargetSettings?->isDynamicMode() ?? false);
+
+        if (!$useDynamic || $this->heatTargetSettings === null) {
             return ['target_f' => $staticTargetF, 'dynamic_target_info' => null];
         }
 
-        $ambientTempF = $this->getCalibratedAmbientTempF();
-        $calibrationPoints = $this->heatTargetSettings->getCalibrationPoints();
+        $preview = $this->computeCurveTarget($staticTargetF);
 
-        if ($ambientTempF === null) {
-            // Fallback to static target
+        // Records *why* this target was chosen, so the equipment event log can tell a
+        // per-job decision apart from one the global default made.
+        $source = $dynamicOverride === null ? 'global_default' : 'per_job';
+
+        if ($preview['fallback']) {
             return [
                 'target_f' => $staticTargetF,
                 'dynamic_target_info' => [
@@ -958,23 +1029,23 @@ class TargetTemperatureService
                     'static_target_f' => $staticTargetF,
                     'clamped' => false,
                     'fallback' => true,
-                    'fallback_reason' => 'ambient_sensor_unavailable',
+                    'fallback_reason' => $preview['fallback_reason'],
+                    'source' => $source,
                 ],
             ];
         }
 
-        $result = DynamicTargetCalculator::calculate($ambientTempF, $calibrationPoints);
-
         return [
-            'target_f' => $result['target_f'],
+            'target_f' => $preview['computed_target_f'],
             'dynamic_target_info' => [
                 'dynamic_mode' => true,
-                'ambient_temp_f' => $ambientTempF,
-                'computed_target_f' => $result['target_f'],
+                'ambient_temp_f' => $preview['ambient_temp_f'],
+                'computed_target_f' => $preview['computed_target_f'],
                 'static_target_f' => $staticTargetF,
-                'segment' => $result['segment'],
-                'clamped' => $result['clamped'],
+                'segment' => $preview['segment'],
+                'clamped' => $preview['clamped'],
                 'fallback' => false,
+                'source' => $source,
             ],
         ];
     }

--- a/backend/storage/bin/cron-runner.sh
+++ b/backend/storage/bin/cron-runner.sh
@@ -172,12 +172,18 @@ fi
 FULL_URL="${API_BASE_URL}${ENDPOINT}"
 
 # Extract params object if present (for heat-to-target jobs)
-# This extracts the entire params JSON object: {"target_temp_f": 103.5}
+# This extracts the entire params JSON object: {"target_temp_f": 103.5, "dynamic": true}
+#
+# CONSTRAINT: params MUST stay FLAT (scalars only).
+# The [^}]* below stops at the FIRST closing brace, so a nested object inside params
+# yields truncated, invalid JSON and the heat silently fires with an empty body.
+# Adding e.g. a per-job calibration curve requires rewriting this parsing first
+# (jq is not available on the shared host).
 REQUEST_BODY=""
 if grep -q '"params"' "$JOB_FILE" 2>/dev/null; then
-    # Extract the params value - handles nested JSON object
+    # Extract the params value
     # Use tr to collapse multi-line JSON to single line first (JSON_PRETTY_PRINT creates multi-line)
-    # Then sed extracts everything between "params": and the matching closing brace
+    # Then sed extracts everything between "params": and the first closing brace
     REQUEST_BODY=$(tr -d '\n' < "$JOB_FILE" | sed -n 's/.*"params"[[:space:]]*:[[:space:]]*\({[^}]*}\).*/\1/p' || true)
     if [ -n "$REQUEST_BODY" ]; then
         log "Using request body: $REQUEST_BODY"

--- a/backend/tests/Controllers/ScheduleControllerTest.php
+++ b/backend/tests/Controllers/ScheduleControllerTest.php
@@ -832,6 +832,157 @@ class ScheduleControllerTest extends TestCase
         $saved = json_decode(file_get_contents($this->jobsDir . '/' . $parentId . '.json'), true);
         $this->assertNotEquals('08:30', $saved['scheduledTime']); // untouched
     }
+
+    // ========== Per-job heat mode (params.dynamic) ==========
+    //
+    // The mode is STAMPED at creation, which is what makes a job keep the
+    // configuration it was built with: later flipping the global default must not
+    // retroactively change what an already-scheduled job does.
+
+    public function testCreateStampsGlobalDynamicDefaultOntoNewJob(): void
+    {
+        [$controller, $settings] = $this->dtdtController();
+        $settings->updateDynamicSettings(true, $settings->getCalibrationPoints());
+
+        $jobId = $controller->create([
+            'action' => 'heat-to-target',
+            'scheduledTime' => (new \DateTime('+2 hours'))->format(\DateTime::ATOM),
+            'target_temp_f' => 102,
+        ])['body']['jobId'];
+
+        $this->assertTrue($this->scheduler->getJob($jobId)['params']['dynamic']);
+    }
+
+    public function testCreateStampsFalseWhenGlobalDefaultIsOff(): void
+    {
+        [$controller, $settings] = $this->dtdtController();
+        $settings->updateDynamicSettings(false, $settings->getCalibrationPoints());
+
+        $jobId = $controller->create([
+            'action' => 'heat-to-target',
+            'scheduledTime' => (new \DateTime('+2 hours'))->format(\DateTime::ATOM),
+            'target_temp_f' => 102,
+        ])['body']['jobId'];
+
+        $this->assertFalse($this->scheduler->getJob($jobId)['params']['dynamic']);
+    }
+
+    public function testCreateHonorsExplicitDynamicOverGlobalDefault(): void
+    {
+        [$controller, $settings] = $this->dtdtController();
+        $settings->updateDynamicSettings(false, $settings->getCalibrationPoints());
+
+        $jobId = $controller->create([
+            'action' => 'heat-to-target',
+            'scheduledTime' => (new \DateTime('+2 hours'))->format(\DateTime::ATOM),
+            'target_temp_f' => 102,
+            'dynamic' => true,
+        ])['body']['jobId'];
+
+        $this->assertTrue($this->scheduler->getJob($jobId)['params']['dynamic']);
+    }
+
+    public function testCreateDoesNotStampDynamicOnNonHeatJobs(): void
+    {
+        [$controller, $settings] = $this->dtdtController();
+        $settings->updateDynamicSettings(true, $settings->getCalibrationPoints());
+
+        $jobId = $controller->create([
+            'action' => 'pump-run',
+            'scheduledTime' => (new \DateTime('+2 hours'))->format(\DateTime::ATOM),
+        ])['body']['jobId'];
+
+        $this->assertArrayNotHasKey('dynamic', $this->scheduler->getJob($jobId)['params'] ?? []);
+    }
+
+    /**
+     * overrideNext() rebuilds params from scratch, so without explicit propagation an
+     * override of an ambient-matched daily job would silently come out fixed.
+     */
+    public function testOverrideNextInheritsParentDynamicMode(): void
+    {
+        [$controller, $settings] = $this->dtdtController();
+        $settings->updateDynamicSettings(true, $settings->getCalibrationPoints());
+        $parentId = $this->createRecurringParent($controller);
+
+        $controller->overrideNext($parentId, ['scheduledTime' => '08:00', 'target_temp_f' => 104]);
+
+        $overrides = $this->findOverrides($parentId);
+        $this->assertCount(1, $overrides);
+        $this->assertTrue($overrides[0]['params']['dynamic']);
+    }
+
+    public function testOverrideNextInheritsFixedModeFromParent(): void
+    {
+        [$controller, $settings] = $this->dtdtController();
+        $settings->updateDynamicSettings(false, $settings->getCalibrationPoints());
+        $parentId = $this->createRecurringParent($controller);
+
+        // Global default flips AFTER the parent was created — the override must follow
+        // the parent, not the new default.
+        $settings->updateDynamicSettings(true, $settings->getCalibrationPoints());
+        $controller->overrideNext($parentId, ['scheduledTime' => '08:00', 'target_temp_f' => 104]);
+
+        $overrides = $this->findOverrides($parentId);
+        $this->assertFalse($overrides[0]['params']['dynamic']);
+    }
+
+    // ========== PUT /api/schedule/{id}/heat-mode ==========
+
+    public function testUpdateHeatModeFlipsTheFlagAndPreservesTemp(): void
+    {
+        [$controller, $settings] = $this->dtdtController();
+        $settings->updateDynamicSettings(false, $settings->getCalibrationPoints());
+        $jobId = $controller->create([
+            'action' => 'heat-to-target',
+            'scheduledTime' => (new \DateTime('+2 hours'))->format(\DateTime::ATOM),
+            'target_temp_f' => 102.25,
+        ])['body']['jobId'];
+
+        $resp = $controller->updateHeatMode($jobId, ['dynamic' => true]);
+
+        $this->assertEquals(200, $resp['status']);
+        $params = $this->scheduler->getJob($jobId)['params'];
+        $this->assertTrue($params['dynamic']);
+        $this->assertEquals(102.25, $params['target_temp_f']);
+    }
+
+    public function testUpdateHeatModeReturns400ForMissingField(): void
+    {
+        [$controller] = $this->dtdtController();
+        $jobId = $controller->create([
+            'action' => 'heat-to-target',
+            'scheduledTime' => (new \DateTime('+2 hours'))->format(\DateTime::ATOM),
+            'target_temp_f' => 102,
+        ])['body']['jobId'];
+
+        $resp = $controller->updateHeatMode($jobId, []);
+
+        $this->assertEquals(400, $resp['status']);
+        $this->assertStringContainsString('dynamic', $resp['body']['error']);
+    }
+
+    public function testUpdateHeatModeReturns404ForMissingJob(): void
+    {
+        [$controller] = $this->dtdtController();
+
+        $resp = $controller->updateHeatMode('job-doesnotexist', ['dynamic' => true]);
+
+        $this->assertEquals(404, $resp['status']);
+    }
+
+    public function testUpdateHeatModeReturns400ForNonHeatJob(): void
+    {
+        [$controller] = $this->dtdtController();
+        $jobId = $controller->create([
+            'action' => 'pump-run',
+            'scheduledTime' => (new \DateTime('+2 hours'))->format(\DateTime::ATOM),
+        ])['body']['jobId'];
+
+        $resp = $controller->updateHeatMode($jobId, ['dynamic' => true]);
+
+        $this->assertEquals(400, $resp['status']);
+    }
 }
 
 /**

--- a/backend/tests/Controllers/TargetTemperatureControllerTest.php
+++ b/backend/tests/Controllers/TargetTemperatureControllerTest.php
@@ -110,6 +110,66 @@ class TargetTemperatureControllerTest extends TestCase
         $this->assertStringContainsString('already active', $response2['body']['error']);
     }
 
+    // ── Per-job heat mode pass-through ────────────────────────────────────────
+    //
+    // The job's stored params land here verbatim as the request body (cron-runner.sh
+    // POSTs the params object), so `dynamic` must survive as a TRI-state: present →
+    // decide for this heat, absent → inherit the global default.
+
+    public function testStartPassesDynamicTrueToTheService(): void
+    {
+        $service = $this->createMock(TargetTemperatureService::class);
+        $service->expects($this->once())
+            ->method('start')
+            ->with(103.5, true)
+            ->willReturn(['active' => true]);
+
+        (new TargetTemperatureController($service))->start([
+            'target_temp_f' => 103.5,
+            'dynamic' => true,
+        ]);
+    }
+
+    public function testStartPassesDynamicFalseToTheService(): void
+    {
+        $service = $this->createMock(TargetTemperatureService::class);
+        $service->expects($this->once())
+            ->method('start')
+            ->with(103.5, false)
+            ->willReturn(['active' => true]);
+
+        (new TargetTemperatureController($service))->start([
+            'target_temp_f' => 103.5,
+            'dynamic' => false,
+        ]);
+    }
+
+    public function testStartPassesNullWhenDynamicIsAbsent(): void
+    {
+        $service = $this->createMock(TargetTemperatureService::class);
+        $service->expects($this->once())
+            ->method('start')
+            ->with(103.5, null)
+            ->willReturn(['active' => true]);
+
+        (new TargetTemperatureController($service))->start(['target_temp_f' => 103.5]);
+    }
+
+    /** A null value must collapse to "inherit", not to false (isset() would get this wrong). */
+    public function testStartPassesNullWhenDynamicIsExplicitlyNull(): void
+    {
+        $service = $this->createMock(TargetTemperatureService::class);
+        $service->expects($this->once())
+            ->method('start')
+            ->with(103.5, null)
+            ->willReturn(['active' => true]);
+
+        (new TargetTemperatureController($service))->start([
+            'target_temp_f' => 103.5,
+            'dynamic' => null,
+        ]);
+    }
+
     protected function tearDown(): void
     {
         // Clean up lock file too

--- a/backend/tests/Services/DtdtServiceTest.php
+++ b/backend/tests/Services/DtdtServiceTest.php
@@ -572,6 +572,200 @@ class DtdtServiceTest extends TestCase
         $this->assertEquals('America/Los_Angeles', $jobData['params']['timezone']);
     }
 
+    // ==================== Per-job heat mode propagation ====================
+    //
+    // handleWakeUp() and startImmediately() both build their params/args from
+    // scratch, so the job's heat mode has to be carried across explicitly or a
+    // ready-by ambient-matched job quietly heats to a fixed temperature.
+
+    /**
+     * @test
+     */
+    public function wakeUpCarriesDynamicOntoThePrecisionOneOff(): void
+    {
+        $this->writeHeatingChars([
+            'heating_velocity_f_per_min' => 0.5,
+            'startup_lag_minutes' => 5.0,
+            'max_cooling_k' => 0.0005,
+        ]);
+
+        $service = $this->createService(null, $this->createMockCalibratedService(98.0, 50.0));
+        $readyByTime = (new \DateTime('+3 hours', new \DateTimeZone('UTC')))->format('H:i') . '+00:00';
+
+        $result = $service->handleWakeUp([
+            'ready_by_time' => $readyByTime,
+            'target_temp_f' => 103.0,
+            'dynamic' => true,
+        ]);
+
+        $this->assertEquals('precision_scheduled', $result['status']);
+        $jobData = json_decode(file_get_contents($this->jobsDir . '/' . $result['jobId'] . '.json'), true);
+        $this->assertTrue($jobData['params']['dynamic']);
+        // The stored temp stays the STATIC fallback — the curve is re-read at heat start,
+        // not frozen here at wake-up.
+        $this->assertEquals(103.0, $jobData['params']['target_temp_f']);
+    }
+
+    /**
+     * @test
+     */
+    public function wakeUpCarriesFixedModeOntoThePrecisionOneOff(): void
+    {
+        $this->writeHeatingChars([
+            'heating_velocity_f_per_min' => 0.5,
+            'startup_lag_minutes' => 5.0,
+            'max_cooling_k' => 0.0005,
+        ]);
+
+        $service = $this->createService(null, $this->createMockCalibratedService(98.0, 50.0));
+        $readyByTime = (new \DateTime('+3 hours', new \DateTimeZone('UTC')))->format('H:i') . '+00:00';
+
+        $result = $service->handleWakeUp([
+            'ready_by_time' => $readyByTime,
+            'target_temp_f' => 103.0,
+            'dynamic' => false,
+        ]);
+
+        $jobData = json_decode(file_get_contents($this->jobsDir . '/' . $result['jobId'] . '.json'), true);
+        $this->assertFalse($jobData['params']['dynamic']);
+    }
+
+    /**
+     * A job predating per-job mode carries no flag; the one-off must not invent one,
+     * so it keeps inheriting the global default at heat time.
+     */
+    public function testWakeUpOmitsDynamicForLegacyJobs(): void
+    {
+        $this->writeHeatingChars([
+            'heating_velocity_f_per_min' => 0.5,
+            'startup_lag_minutes' => 5.0,
+            'max_cooling_k' => 0.0005,
+        ]);
+
+        $service = $this->createService(null, $this->createMockCalibratedService(98.0, 50.0));
+        $readyByTime = (new \DateTime('+3 hours', new \DateTimeZone('UTC')))->format('H:i') . '+00:00';
+
+        $result = $service->handleWakeUp([
+            'ready_by_time' => $readyByTime,
+            'target_temp_f' => 103.0,
+        ]);
+
+        $jobData = json_decode(file_get_contents($this->jobsDir . '/' . $result['jobId'] . '.json'), true);
+        $this->assertArrayNotHasKey('dynamic', $jobData['params']);
+    }
+
+    /**
+     * @test
+     */
+    public function startImmediatelyPassesTheJobsHeatModeThrough(): void
+    {
+        $this->writeHeatingChars([
+            'heating_velocity_f_per_min' => 0.5,
+            'startup_lag_minutes' => 5.0,
+        ]);
+
+        $targetService = $this->createMock(TargetTemperatureService::class);
+        $targetService->expects($this->once())
+            ->method('start')
+            ->with(103.0, true)
+            ->willReturn([]);
+
+        // No calibrated temp service → no water reading → conservative immediate start.
+        $service = $this->createService($targetService, null);
+
+        $result = $service->handleWakeUp([
+            'ready_by_time' => (new \DateTime('+3 hours', new \DateTimeZone('UTC')))->format('H:i') . '+00:00',
+            'target_temp_f' => 103.0,
+            'dynamic' => true,
+        ]);
+
+        $this->assertEquals('started_immediately', $result['status']);
+    }
+
+    /**
+     * Lead-time correctness: the cooling projection and precision start were computed
+     * from the STATIC temp while the heat later aimed at the ambient-derived one. When
+     * the curve calls for a materially hotter target, that made the tub late to its
+     * ready-by time.
+     *
+     * @test
+     */
+    public function wakeUpComputesLeadTimeAgainstTheProjectedTarget(): void
+    {
+        $this->writeHeatingChars([
+            'heating_velocity_f_per_min' => 0.5,
+            'startup_lag_minutes' => 5.0,
+            'max_cooling_k' => 0.0005,
+        ]);
+
+        // Cold outside: the curve wants 106°F, six degrees above the stored 100°F.
+        $targetService = $this->createMock(TargetTemperatureService::class);
+        $targetService->method('previewDynamicTarget')->willReturn([
+            'ambient_temp_f' => 38.0,
+            'computed_target_f' => 106.0,
+            'segment' => 'clamp_low',
+            'clamped' => true,
+            'fallback' => false,
+        ]);
+
+        $readyByTime = (new \DateTime('+3 hours', new \DateTimeZone('UTC')))->format('H:i') . '+00:00';
+
+        $dynamicResult = $this->createService($targetService, $this->createMockCalibratedService(98.0, 38.0))
+            ->handleWakeUp([
+                'ready_by_time' => $readyByTime,
+                'target_temp_f' => 100.0,
+                'dynamic' => true,
+            ]);
+
+        $fixedResult = $this->createService($targetService, $this->createMockCalibratedService(98.0, 38.0))
+            ->handleWakeUp([
+                'ready_by_time' => $readyByTime,
+                'target_temp_f' => 100.0,
+                'dynamic' => false,
+            ]);
+
+        $this->assertEquals('precision_scheduled', $dynamicResult['status']);
+        $this->assertEquals('precision_scheduled', $fixedResult['status']);
+        // 6°F further to climb at 0.5°F/min ≈ 12 extra minutes of lead time.
+        $this->assertGreaterThan($fixedResult['heat_minutes'] + 10, $dynamicResult['heat_minutes']);
+        $this->assertEquals(106.0, $dynamicResult['target_temp_f']);
+    }
+
+    /**
+     * A dynamic job whose ambient sensor is down must fall back to the stored temp for
+     * the lead-time math rather than skipping the heat or crashing.
+     *
+     * @test
+     */
+    public function wakeUpFallsBackToStaticTargetWhenTheProjectionIsUnavailable(): void
+    {
+        $this->writeHeatingChars([
+            'heating_velocity_f_per_min' => 0.5,
+            'startup_lag_minutes' => 5.0,
+            'max_cooling_k' => 0.0005,
+        ]);
+
+        $targetService = $this->createMock(TargetTemperatureService::class);
+        $targetService->method('previewDynamicTarget')->willReturn([
+            'ambient_temp_f' => null,
+            'computed_target_f' => 103.0,
+            'clamped' => false,
+            'fallback' => true,
+            'fallback_reason' => 'ambient_sensor_unavailable',
+        ]);
+
+        $service = $this->createService($targetService, $this->createMockCalibratedService(98.0, 50.0));
+
+        $result = $service->handleWakeUp([
+            'ready_by_time' => (new \DateTime('+3 hours', new \DateTimeZone('UTC')))->format('H:i') . '+00:00',
+            'target_temp_f' => 103.0,
+            'dynamic' => true,
+        ]);
+
+        $this->assertEquals('precision_scheduled', $result['status']);
+        $this->assertEquals(103.0, $result['target_temp_f']);
+    }
+
     // ==================== Helper Methods ====================
 
     private function createMockCalibratedService(float $waterTempF, float $ambientTempF): Esp32CalibratedTemperatureService

--- a/backend/tests/Services/TargetTemperatureServiceTest.php
+++ b/backend/tests/Services/TargetTemperatureServiceTest.php
@@ -1690,4 +1690,219 @@ class TargetTemperatureServiceTest extends TestCase
         rmdir($stateDir);
         rmdir($tempDir);
     }
+
+    // ── Per-job dynamic heat mode ──────────────────────────────────────────────
+    //
+    // The heat mode is a property of each scheduled job, so start() takes an
+    // override: true/false decide for this heat alone, null inherits the global
+    // default (the no-migration path for jobs created before per-job mode).
+
+    public function testStartWithDynamicOverrideTrueUsesCurveWhileGlobalIsOff(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(false);
+        $service = $this->createServiceWithDynamic($heatSettings);
+
+        // Ambient 52.5F (cold-segment midpoint) → 103.0F
+        $this->storeEsp32ReadingWithAmbient(90.0, 52.5);
+        $this->mockIfttt->expects($this->atLeastOnce())->method('trigger');
+
+        $service->start(102.0, true);
+
+        $state = $service->getState();
+        $this->assertEqualsWithDelta(103.0, $state['target_temp_f'], 0.01);
+        $this->assertArrayHasKey('dynamic_target_info', $state);
+        $this->assertSame('per_job', $state['dynamic_target_info']['source']);
+    }
+
+    public function testStartWithDynamicOverrideFalseUsesStaticWhileGlobalIsOn(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(true);
+        $service = $this->createServiceWithDynamic($heatSettings);
+
+        $this->storeEsp32ReadingWithAmbient(90.0, 52.5);
+        $this->mockIfttt->expects($this->atLeastOnce())->method('trigger');
+
+        $service->start(102.0, false);
+
+        $state = $service->getState();
+        $this->assertEqualsWithDelta(102.0, $state['target_temp_f'], 0.01);
+        $this->assertArrayNotHasKey('dynamic_target_info', $state);
+    }
+
+    public function testStartWithNullDynamicFollowsGlobalWhenOn(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(true);
+        $service = $this->createServiceWithDynamic($heatSettings);
+
+        $this->storeEsp32ReadingWithAmbient(90.0, 52.5);
+        $this->mockIfttt->expects($this->atLeastOnce())->method('trigger');
+
+        $service->start(102.0, null);
+
+        $state = $service->getState();
+        $this->assertEqualsWithDelta(103.0, $state['target_temp_f'], 0.01);
+        $this->assertSame('global_default', $state['dynamic_target_info']['source']);
+    }
+
+    public function testStartWithNullDynamicFollowsGlobalWhenOff(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(false);
+        $service = $this->createServiceWithDynamic($heatSettings);
+
+        $this->storeEsp32ReadingWithAmbient(90.0, 52.5);
+        $this->mockIfttt->expects($this->atLeastOnce())->method('trigger');
+
+        $service->start(102.0, null);
+
+        $state = $service->getState();
+        $this->assertEqualsWithDelta(102.0, $state['target_temp_f'], 0.01);
+        $this->assertArrayNotHasKey('dynamic_target_info', $state);
+    }
+
+    // ── previewDynamicTarget() ────────────────────────────────────────────────
+
+    public function testPreviewDynamicTargetIsNullWithoutSettings(): void
+    {
+        $service = new TargetTemperatureService($this->stateFile);
+
+        $this->assertNull($service->previewDynamicTarget());
+    }
+
+    /**
+     * Scheduled heat-to-target jobs outlive the household "Enable heat to target"
+     * toggle, so gating the projection on it would blank cards that still heat.
+     */
+    public function testPreviewDynamicTargetStillComputesWhenHeatToTargetIsDisabled(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(true);
+        $heatSettings->updateSettings(false, 102.0); // heat-to-target feature off
+        $service = $this->createServiceWithDynamic($heatSettings);
+        $this->storeEsp32ReadingWithAmbient(90.0, 52.5);
+
+        $this->assertEqualsWithDelta(103.0, $service->previewDynamicTarget()['computed_target_f'], 0.01);
+    }
+
+    /**
+     * The projection must survive the global default being off — that's the whole
+     * point of per-job mode: leave the household default fixed, mark single jobs
+     * as ambient-matched. Gating the preview on dynamic_mode would blank exactly
+     * the cards that need a number.
+     */
+    public function testPreviewDynamicTargetStillComputesWhenGlobalDefaultIsOff(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(false);
+        $service = $this->createServiceWithDynamic($heatSettings);
+        $this->storeEsp32ReadingWithAmbient(90.0, 52.5);
+
+        $preview = $service->previewDynamicTarget();
+
+        $this->assertNotNull($preview);
+        $this->assertEqualsWithDelta(103.0, $preview['computed_target_f'], 0.01);
+    }
+
+    public function testPreviewDynamicTargetInterpolatesColdSegment(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(true);
+        $service = $this->createServiceWithDynamic($heatSettings);
+        $this->storeEsp32ReadingWithAmbient(90.0, 52.5);
+
+        $preview = $service->previewDynamicTarget();
+
+        $this->assertNotNull($preview);
+        $this->assertEqualsWithDelta(52.5, $preview['ambient_temp_f'], 0.01);
+        $this->assertEqualsWithDelta(103.0, $preview['computed_target_f'], 0.01);
+        $this->assertSame('cold', $preview['segment']);
+        $this->assertFalse($preview['clamped']);
+        $this->assertFalse($preview['fallback']);
+    }
+
+    public function testPreviewDynamicTargetInterpolatesHotSegment(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(true);
+        $service = $this->createServiceWithDynamic($heatSettings);
+        // Ambient 67.5F (midpoint of comfort 60 → hot 75) → (102.0 + 100.5) / 2
+        $this->storeEsp32ReadingWithAmbient(90.0, 67.5);
+
+        $preview = $service->previewDynamicTarget();
+
+        $this->assertEqualsWithDelta(101.25, $preview['computed_target_f'], 0.01);
+        $this->assertSame('hot', $preview['segment']);
+    }
+
+    public function testPreviewDynamicTargetClampsLow(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(true);
+        $service = $this->createServiceWithDynamic($heatSettings);
+        $this->storeEsp32ReadingWithAmbient(90.0, 30.0);
+
+        $preview = $service->previewDynamicTarget();
+
+        $this->assertEqualsWithDelta(104.0, $preview['computed_target_f'], 0.01);
+        $this->assertSame('clamp_low', $preview['segment']);
+        $this->assertTrue($preview['clamped']);
+    }
+
+    public function testPreviewDynamicTargetClampsHigh(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(true);
+        $service = $this->createServiceWithDynamic($heatSettings);
+        $this->storeEsp32ReadingWithAmbient(90.0, 95.0);
+
+        $preview = $service->previewDynamicTarget();
+
+        $this->assertEqualsWithDelta(100.5, $preview['computed_target_f'], 0.01);
+        $this->assertSame('clamp_high', $preview['segment']);
+        $this->assertTrue($preview['clamped']);
+    }
+
+    public function testPreviewDynamicTargetFallsBackWhenAmbientMissing(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(true);
+        $service = $this->createServiceWithDynamic($heatSettings);
+        $this->storeEsp32Reading(90.0); // water only
+
+        $preview = $service->previewDynamicTarget();
+
+        $this->assertNotNull($preview);
+        $this->assertTrue($preview['fallback']);
+        $this->assertSame('ambient_sensor_unavailable', $preview['fallback_reason']);
+        $this->assertNull($preview['ambient_temp_f']);
+        $this->assertArrayNotHasKey('segment', $preview);
+    }
+
+    public function testPreviewDynamicTargetHonorsAmbientCalibrationOffset(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(true);
+        $service = $this->createServiceWithDynamic($heatSettings);
+        $this->storeEsp32ReadingWithAmbient(90.0, 52.5);
+
+        $uncalibrated = $service->previewDynamicTarget();
+
+        // +5°C offset on the ambient sensor → +9°F on the reading
+        $this->esp32Config->setCalibrationOffset('28:BB:CC:DD:EE:FF:00:11', 5.0);
+        $calibrated = $service->previewDynamicTarget();
+
+        $this->assertEqualsWithDelta(
+            $uncalibrated['ambient_temp_f'] + 9.0,
+            $calibrated['ambient_temp_f'],
+            0.01
+        );
+    }
+
+    public function testPreviewDynamicTargetMatchesWhatStartWrites(): void
+    {
+        $heatSettings = $this->createDynamicHeatTargetSettings(true);
+        $service = $this->createServiceWithDynamic($heatSettings);
+        $this->storeEsp32ReadingWithAmbient(90.0, 52.5);
+        $this->mockIfttt->expects($this->atLeastOnce())->method('trigger');
+
+        $preview = $service->previewDynamicTarget();
+        $service->start(102.0);
+
+        $this->assertEqualsWithDelta(
+            $preview['computed_target_f'],
+            $service->getState()['target_temp_f'],
+            0.001
+        );
+    }
 }

--- a/frontend/e2e/heat-target-settings.spec.ts
+++ b/frontend/e2e/heat-target-settings.spec.ts
@@ -378,7 +378,7 @@ test.describe('Heat Target Settings (Admin Only)', () => {
 
 		test('displays target mode radio buttons for admin', async ({ page }) => {
 			await expect(page.getByLabel('Static target')).toBeVisible({ timeout: 10000 });
-			await expect(page.getByLabel('Dynamic (ambient-adjusted)')).toBeVisible();
+			await expect(page.getByLabel('Based on ambient temp')).toBeVisible();
 		});
 
 		test('static mode is selected by default', async ({ page }) => {
@@ -391,7 +391,7 @@ test.describe('Heat Target Settings (Admin Only)', () => {
 			await expect(page.getByLabel('Target temp', { exact: true })).toBeVisible({ timeout: 10000 });
 
 			// Switch to dynamic
-			await page.getByLabel('Dynamic (ambient-adjusted)').click();
+			await page.getByLabel('Based on ambient temp').click();
 
 			// Slider should be hidden, calibration inputs should appear
 			await expect(page.getByLabel('Target temp', { exact: true })).not.toBeVisible();
@@ -402,7 +402,7 @@ test.describe('Heat Target Settings (Admin Only)', () => {
 
 		test('switching to dynamic mode marks settings as dirty', async ({ page }) => {
 			await expect(page.getByLabel('Static target')).toBeVisible({ timeout: 10000 });
-			await page.getByLabel('Dynamic (ambient-adjusted)').click();
+			await page.getByLabel('Based on ambient temp').click();
 			await expect(page.getByRole('button', { name: 'Save Settings' })).toBeVisible();
 		});
 
@@ -410,7 +410,7 @@ test.describe('Heat Target Settings (Admin Only)', () => {
 			await expect(page.getByLabel('Static target')).toBeVisible({ timeout: 10000 });
 
 			// Switch to dynamic and save
-			await page.getByLabel('Dynamic (ambient-adjusted)').click();
+			await page.getByLabel('Based on ambient temp').click();
 			await page.getByRole('button', { name: 'Save Settings' }).click();
 
 			// Wait for save to complete (button disappears when not dirty)
@@ -421,7 +421,7 @@ test.describe('Heat Target Settings (Admin Only)', () => {
 			await expect(page.getByRole('heading', { name: 'Schedule', exact: true })).toBeVisible({
 				timeout: 10000
 			});
-			await expect(page.getByLabel('Dynamic (ambient-adjusted)')).toBeChecked({ timeout: 5000 });
+			await expect(page.getByLabel('Based on ambient temp')).toBeChecked({ timeout: 5000 });
 		});
 
 		test('calibration point values persist after save and reload', async ({ page }) => {
@@ -447,7 +447,7 @@ test.describe('Heat Target Settings (Admin Only)', () => {
 			});
 
 			// Verify dynamic mode is active
-			await expect(page.getByLabel('Dynamic (ambient-adjusted)')).toBeChecked({ timeout: 5000 });
+			await expect(page.getByLabel('Based on ambient temp')).toBeChecked({ timeout: 5000 });
 
 			// Verify calibration values loaded
 			await expect(page.getByLabel('Cold ambient temp')).toHaveValue('40');

--- a/frontend/e2e/v2-home.spec.ts
+++ b/frontend/e2e/v2-home.spec.ts
@@ -246,6 +246,65 @@ test.describe('v2 Home (MVP)', () => {
 			await expect(card).toHaveCount(0, { timeout: 10000 });
 			expect(await tempOf()).toBeUndefined();
 		});
+
+		// Home passes EventCard a different callback set than the Schedule tab, so a prop
+		// wired at only one site means Home quietly loses the control.
+		test('an ambient-matched card explains itself and can be switched from Home', async ({
+			page
+		}) => {
+			const list = await (await page.request.get('/tub/backend/public/api/schedule')).json();
+			for (const j of list.jobs ?? []) {
+				await page.request.delete(`/tub/backend/public/api/schedule/${j.jobId}`);
+			}
+			// Pin the curve: heat-target-settings.spec.ts persists its own (40°→105 …), and
+			// global-setup only resets once per RUN, so the projection isn't otherwise stable.
+			await page.request.put('/tub/backend/public/api/settings/heat-target', {
+				data: {
+					enabled: false,
+					target_temp_f: 103.0,
+					dynamic_mode: false,
+					calibration_points: {
+						cold: { ambient_f: 45.0, water_target_f: 104.0 },
+						comfort: { ambient_f: 60.0, water_target_f: 102.0 },
+						hot: { ambient_f: 75.0, water_target_f: 100.5 }
+					}
+				}
+			});
+			const when = new Date(Date.now() + 24 * 3600 * 1000);
+			when.setHours(16, 30, 0, 0);
+			const res = await page.request.post('/tub/backend/public/api/schedule', {
+				data: {
+					action: 'heat-to-target',
+					scheduledTime: when.toISOString(),
+					recurring: false,
+					target_temp_f: 109.25,
+					dynamic: true
+				}
+			});
+			expect(res.ok()).toBeTruthy();
+			const jobId = (await res.json()).jobId;
+
+			await page.reload();
+			const card = page.locator(`[data-testid="event-card"][data-key="${jobId}"]`);
+			await expect(card).toBeVisible({ timeout: 15000 });
+			await expect(card.getByTestId('event-title')).toHaveText('Heat based on ambient temp');
+
+			// The fixture's 55.004°F ambient interpolates to 102.67°F on the default curve.
+			await card.getByTestId('event-dynamic-chip').click();
+			await expect(card.getByTestId('event-dynamic-projection')).toContainText('≈102.67°F now');
+			await expect(card.getByTestId('event-dynamic-setup-link')).toBeVisible(); // admin
+
+			// Switching back to a fixed temperature restores the saved number and the stepper.
+			await card.getByTestId('event-dynamic-mode-switch').click();
+			await expect(card.getByTestId('event-title')).toHaveText('Heat to 109.25°F', {
+				timeout: 10000
+			});
+			await expect(card.getByTestId('event-oneoff-temp')).toBeVisible();
+
+			const saved = (await (await page.request.get('/tub/backend/public/api/schedule')).json())
+				.jobs as Array<{ jobId: string; params?: { dynamic?: boolean } }>;
+			expect(saved.find((j) => j.jobId === jobId)?.params?.dynamic).toBe(false);
+		});
 	});
 
 	test.describe('Heat-now target dial', () => {

--- a/frontend/e2e/v2-schedule.spec.ts
+++ b/frontend/e2e/v2-schedule.spec.ts
@@ -249,3 +249,157 @@ test.describe('v2 Schedule tab', () => {
 		await page.request.delete(`/tub/backend/public/api/schedule/${jobId}`).catch(() => {});
 	});
 });
+
+/**
+ * Per-job heat mode: a card follows either a fixed temperature or the ambient curve,
+ * and the choice belongs to that job alone.
+ *
+ * The ambient fixture is deterministic — global-setup writes temp_c 12.78 with
+ * calibration_offset 0 (55.004°F), which against the default curve (45°→104, 60°→102)
+ * interpolates to 102.67°F — so the projection can be asserted exactly.
+ */
+test.describe('v2 Schedule per-job heat mode', () => {
+	const createdJobIds: string[] = [];
+
+	// heat-target-settings.spec.ts persists its own curve (40°→105 …), so the projection
+	// is only deterministic if this spec pins the curve itself rather than trusting
+	// global-setup, which runs once per RUN and not between specs.
+	const DEFAULT_SETTINGS = {
+		enabled: false,
+		target_temp_f: 103.0,
+		dynamic_mode: false,
+		calibration_points: {
+			cold: { ambient_f: 45.0, water_target_f: 104.0 },
+			comfort: { ambient_f: 60.0, water_target_f: 102.0 },
+			hot: { ambient_f: 75.0, water_target_f: 100.5 }
+		}
+	};
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/tub/login');
+		await page.fill('#username', 'admin');
+		await page.fill('#password', 'password');
+		await page.press('#password', 'Enter');
+		await expect(page.getByRole('button', { name: 'Logout' })).toBeVisible({ timeout: 15000 });
+		await page.request.put('/tub/backend/public/api/settings/heat-target', {
+			data: DEFAULT_SETTINGS
+		});
+		await page.goto('/tub/schedule/');
+		await expect(page.getByTestId('v2-schedule')).toBeVisible({ timeout: 15000 });
+	});
+
+	// dynamic_mode is GLOBAL persisted state in storage/state/heat-target-settings.json —
+	// leaking it on would break heat-target-settings.spec.ts and control-buttons.spec.ts
+	// depending on order.
+	test.afterEach(async ({ page }) => {
+		for (const id of createdJobIds.splice(0)) {
+			await page.request.delete(`/tub/backend/public/api/schedule/${id}`).catch(() => {});
+		}
+		await page.request
+			.put('/tub/backend/public/api/settings/heat-target', { data: DEFAULT_SETTINGS })
+			.catch(() => {});
+	});
+
+	/** Adds a one-off heat event and returns the card locator, keyed by its real job id. */
+	async function addHeatEvent(page, temp: string, dynamic: boolean) {
+		await page.getByTestId('schedule-add').click();
+		const sheet = page.getByTestId('schedule-add-sheet');
+		await expect(sheet).toBeVisible();
+		await sheet.getByTestId(dynamic ? 'add-mode-dynamic' : 'add-mode-fixed').click();
+		await sheet.getByTestId('add-temp').fill(temp);
+		await sheet.getByTestId('add-time').fill('06:30');
+		await sheet.getByRole('button', { name: 'Once' }).click();
+		await sheet.getByTestId('add-submit').click();
+		await expect(sheet).toHaveCount(0, { timeout: 10000 });
+
+		// Key on the job id, not on card text: a FIXED card also carries the words "Heat
+		// based on ambient temp" in its mode-switch button, so hasText matches both cards.
+		const list = (await (await page.request.get('/tub/backend/public/api/schedule')).json())
+			.jobs as Array<{ jobId: string; params?: { target_temp_f?: number } }>;
+		const jobId = list.find((j) => j.params?.target_temp_f === Number(temp))!.jobId;
+		createdJobIds.push(jobId);
+
+		const card = page.locator(`[data-testid="event-card"][data-key="${jobId}"]`);
+		await expect(card).toBeVisible({ timeout: 10000 });
+		return { card, jobId };
+	}
+
+	test('a fixed and an ambient-matched event read differently, and one mode change leaves the other alone', async ({
+		page
+	}) => {
+		const { card: fixedCard } = await addHeatEvent(page, '104.75', false);
+		const { card: dynamicCard } = await addHeatEvent(page, '101.5', true);
+
+		// The ambient card names its mode and shows NO stored number; the fixed one does.
+		await expect(dynamicCard.getByTestId('event-title')).toHaveText('Heat based on ambient temp');
+		await expect(dynamicCard.getByTestId('event-title')).not.toContainText('101.5');
+		await expect(fixedCard.getByTestId('event-title')).toHaveText('Heat to 104.75°F');
+
+		// The disclosure marks the ambient card only.
+		await expect(dynamicCard.getByTestId('event-dynamic-chip')).toBeVisible();
+		await expect(fixedCard.getByTestId('event-dynamic-chip')).toHaveCount(0);
+
+		// The temp stepper is gone on the ambient card; the TIME stepper stays (its
+		// disappearing was the bug).
+		await expect(dynamicCard.getByTestId('event-oneoff-time')).toBeVisible();
+		await expect(dynamicCard.getByTestId('event-oneoff-temp')).toHaveCount(0);
+		await expect(fixedCard.getByTestId('event-oneoff-temp')).toBeVisible();
+
+		// Expanding shows the live projection against the deterministic fixture:
+		// 55.004°F ambient on a 45°→104 / 60°→102 curve interpolates to 102.67°F.
+		await dynamicCard.getByTestId('event-dynamic-chip').click();
+		await expect(dynamicCard.getByTestId('event-dynamic-projection')).toContainText(
+			'≈102.67°F now'
+		);
+
+		// Flipping ONE job's mode leaves the other untouched.
+		await dynamicCard.getByTestId('event-dynamic-mode-switch').click();
+		await expect(dynamicCard.getByTestId('event-title')).toHaveText('Heat to 101.5°F', {
+			timeout: 10000
+		});
+		await expect(fixedCard.getByTestId('event-title')).toHaveText('Heat to 104.75°F');
+		await expect(fixedCard.getByTestId('event-dynamic-chip')).toHaveCount(0);
+	});
+
+	test('the disclosure opens from the keyboard', async ({ page }) => {
+		const { card } = await addHeatEvent(page, '103.75', true);
+
+		const chip = card.getByTestId('event-dynamic-chip');
+		await expect(chip).toHaveAttribute('aria-expanded', 'false');
+		await chip.press('Enter'); // a native <button> handles this without a key handler
+		await expect(chip).toHaveAttribute('aria-expanded', 'true');
+		await expect(card.getByTestId('event-dynamic-detail')).toBeVisible();
+	});
+
+	test('the household default is stamped onto a new job, not applied retroactively', async ({
+		page
+	}) => {
+		// Default OFF → a new job is fixed.
+		const { card, jobId } = await addHeatEvent(page, '105.75', false);
+		await expect(card.getByTestId('event-title')).toHaveText('Heat to 105.75°F');
+
+		// Turn the household default ON.
+		await page.request.put('/tub/backend/public/api/settings/heat-target', {
+			data: { ...DEFAULT_SETTINGS, dynamic_mode: true }
+		});
+		await page.reload();
+		await expect(page.getByTestId('v2-schedule')).toBeVisible({ timeout: 15000 });
+
+		// The existing job kept the mode it was created with.
+		await expect(card.getByTestId('event-title')).toHaveText('Heat to 105.75°F', {
+			timeout: 10000
+		});
+		const list = (await (await page.request.get('/tub/backend/public/api/schedule')).json())
+			.jobs as Array<{ jobId: string; params?: { dynamic?: boolean } }>;
+		expect(list.find((j) => j.jobId === jobId)?.params?.dynamic).toBe(false);
+	});
+
+	// /api/health is public and the projection carries an outdoor-air reading plus a
+	// sensor-offline signal, so it must not be handed to an anonymous caller.
+	test('an unauthenticated health check carries no ambient projection', async ({ request }) => {
+		const body = await (await request.get('/tub/backend/public/api/health')).json();
+
+		expect(body.heatTargetSettings).toBeTruthy();
+		expect(body.heatTargetSettings.dynamic_preview).toBeUndefined();
+	});
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,6 +19,12 @@ export interface ScheduledJob {
 		ready_by_time?: string;
 		timezone?: string;
 		override_of?: string;
+		/**
+		 * This job's own heat mode: true → follow the ambient curve, false → heat to
+		 * target_temp_f. Absent on jobs created before per-job mode existed — those
+		 * inherit the household default at run time (see jobIsDynamic).
+		 */
+		dynamic?: boolean;
 	};
 	skipped?: boolean;
 	skipDate?: string;
@@ -112,8 +118,14 @@ export interface HeatTargetSettings {
 	schedule_mode?: 'start_at' | 'ready_by';
 	stall_grace_period_minutes?: number;
 	stall_timeout_minutes?: number;
+	/** The DEFAULT stamped onto new jobs (and the mode for manual "Heat now") — not retroactive. */
 	dynamic_mode?: boolean;
 	calibration_points?: CalibrationPoints;
+	/**
+	 * What the ambient curve would pick right now. Present only for an authenticated
+	 * caller (it carries an outdoor-air reading), and null when heat-to-target is off.
+	 */
+	dynamic_preview?: DynamicTargetPreview | null;
 }
 
 export interface LastStallEvent {
@@ -141,7 +153,18 @@ export interface DynamicTargetInfo {
 	clamped: boolean;
 	fallback: boolean;
 	fallback_reason?: string;
+	/** Why this target was chosen: the job's own flag, or the household default. */
+	source?: 'per_job' | 'global_default';
 }
+
+/**
+ * A live projection of the curve — the same shape a heat records, minus the fields that
+ * only exist once a specific heat has committed to a static fallback.
+ */
+export type DynamicTargetPreview = Omit<
+	DynamicTargetInfo,
+	'dynamic_mode' | 'static_target_f' | 'source'
+>;
 
 export interface TargetTemperatureState {
 	active: boolean;
@@ -318,13 +341,17 @@ export const api = {
 		action: string,
 		scheduledTime: string,
 		recurring: boolean = false,
-		params?: { target_temp_f?: number },
+		params?: { target_temp_f?: number; dynamic?: boolean },
 		timezone?: string
 	) => postJson<ScheduledJob>('/api/schedule', { action, scheduledTime, recurring, ...params, ...(timezone ? { timezone } : {}) }),
 	listScheduledJobs: () => get<ScheduleListResponse>('/api/schedule'),
 	cancelScheduledJob: (jobId: string) => del(`/api/schedule/${jobId}`),
 	updateScheduledJobTemp: (jobId: string, targetTempF: number) =>
 		put<ScheduledJob>(`/api/schedule/${jobId}/target-temp`, { target_temp_f: targetTempF }),
+	// Switch one job between a fixed temperature and the ambient-matched curve. Affects
+	// only that job — the household default in Setup is untouched.
+	setScheduledJobHeatMode: (jobId: string, dynamic: boolean) =>
+		put<ScheduledJob>(`/api/schedule/${jobId}/heat-mode`, { dynamic }),
 	skipScheduledJob: (jobId: string) => post(`/api/schedule/${jobId}/skip`),
 	unskipScheduledJob: (jobId: string) => del(`/api/schedule/${jobId}/skip`),
 	// "Adjust just the next run" of a recurring job: skip it + a mode-aware one-off

--- a/frontend/src/lib/components/EventCard.svelte
+++ b/frontend/src/lib/components/EventCard.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
 	import { onDestroy } from 'svelte';
-	import { getDynamicMode } from '$lib/stores/heatTargetSettings.svelte';
+	import { base } from '$app/paths';
+	import {
+		getDynamicMode,
+		getDynamicPreview,
+		getCalibrationPoints
+	} from '$lib/stores/heatTargetSettings.svelte';
 	import {
 		formatNextFire,
 		formatTemp,
 		formatClockHHMM,
 		shiftHHMM,
 		jobTitle,
+		jobIsDynamic,
+		dynamicProjectionLabel,
 		jobClock,
 		resumeLabel,
 		baseSummary,
@@ -30,6 +37,8 @@
 	interface Props {
 		event: LogicalEvent;
 		canAdjust?: boolean;
+		/** Owner-only: link out to the shared ambient curve in Setup. */
+		canConfigureCurve?: boolean;
 		onSkip?: (event: LogicalEvent) => void;
 		onUnskip?: (event: LogicalEvent) => void;
 		onCancel?: (event: LogicalEvent) => void;
@@ -39,10 +48,13 @@
 		onOverrideNext?: (jobId: string, time: string, tempF: number) => Promise<void> | void;
 		onClearOverride?: (event: LogicalEvent) => void;
 		onMakePermanent?: (event: LogicalEvent) => void;
+		/** Flip THIS job between a fixed temperature and the ambient curve. */
+		onSetHeatMode?: (jobId: string, dynamic: boolean) => Promise<void> | void;
 	}
 	let {
 		event,
 		canAdjust = false,
+		canConfigureCurve = false,
 		onSkip,
 		onUnskip,
 		onCancel,
@@ -51,13 +63,20 @@
 		onRescheduleRecurring,
 		onOverrideNext,
 		onClearOverride,
-		onMakePermanent
+		onMakePermanent,
+		onSetHeatMode
 	}: Props = $props();
 
 	// Adjustability is a property of the underlying schedule (the base job); the title
 	// and next-fire line describe the *effective* next run (the override when present).
 	const isHeatToTarget = $derived(event.baseJob.action === 'heat-to-target');
-	const title = $derived(jobTitle(event.job, getDynamicMode()));
+
+	// The heat mode belongs to the job, not the household: getDynamicMode() is only the
+	// fallback for jobs created before per-job mode existed. Read from the EFFECTIVE next
+	// run (the override when present), matching what the title and next-fire line describe;
+	// toggleHeatMode writes both jobs so the two can't drift apart.
+	const followsCurve = $derived(isHeatToTarget && jobIsDynamic(event.job, getDynamicMode()));
+	const title = $derived(jobTitle(event.job, followsCurve));
 
 	// "ready by" when the recurring parent is in ready-by mode, else "start"/one-off.
 	const whenVerb = $derived(
@@ -125,17 +144,18 @@
 	// heat events render the SAME steppers (card parity); they differ only in what
 	// Save means: move the instant, override the next run, or change the daily default.
 	const overrideMode = $derived(!!onOverrideNext);
-	const oneOffAdjustable = $derived(
-		isHeatToTarget && !event.recurring && !getDynamicMode() && !!onReschedule
-	);
+	const oneOffAdjustable = $derived(isHeatToTarget && !event.recurring && !!onReschedule);
 	const recurringAdjustable = $derived(
 		isHeatToTarget &&
 			event.recurring &&
 			!event.skipped &&
-			!getDynamicMode() &&
 			(overrideMode || !!onRescheduleRecurring)
 	);
 	const stepperAdjustable = $derived(oneOffAdjustable || recurringAdjustable);
+	// Only the TEMP stepper depends on the heat mode — when the curve picks the target
+	// there's nothing to nudge. Time-of-day has nothing to do with how the target is
+	// chosen, so the time stepper stays (its disappearing was a plain bug).
+	const tempAdjustable = $derived(stepperAdjustable && !followsCurve);
 
 	// Override mode edits the *effective* next run (the override one-off when present);
 	// permanent mode edits the everyday default (the base job).
@@ -215,7 +235,9 @@
 	function describeChange(): string {
 		const parts = [draftClockDisplay];
 		if (draftTemp != null) parts.push(`${formatTemp(draftTemp)}°F`);
-		return `${title} → ${parts.join(' · ')}`;
+		// The static form: "Heat based on ambient temp → 7:00 AM · 102.25°F" would read
+		// as nonsense in the unsaved-changes prompt.
+		return `${jobTitle(event.job)} → ${parts.join(' · ')}`;
 	}
 	$effect(() => {
 		const id = `card:${event.key}`;
@@ -231,6 +253,49 @@
 		}
 	});
 	onDestroy(() => clearPendingEdit(`card:${event.key}`));
+
+	// ── Heat-mode disclosure ────────────────────────────────────────────────────
+	// The projection lives INSIDE the expanded region, never in the title: a daily
+	// 6:30 AM heat uses 6:30 AM's air, not right now's, and a number that drifts
+	// between page loads reads as instability.
+	let detailOpen = $state(false);
+	const detailId = $derived(`event-dynamic-detail-${event.key}`);
+	const preview = $derived(getDynamicPreview());
+	// The fallback that matters is the one the run about to fire will use.
+	const savedTempF = $derived(event.job.params?.target_temp_f ?? null);
+	const projectionLabel = $derived(dynamicProjectionLabel(preview, savedTempF));
+
+	// The three shared calibration points as chips, with the segment the current air
+	// sits on highlighted. clamp_low/clamp_high light the endpoint they're held at.
+	const CURVE_KEYS = ['cold', 'comfort', 'hot'] as const;
+	const activeSegment = $derived(preview?.fallback ? null : (preview?.segment ?? null));
+	function pointIsActive(key: (typeof CURVE_KEYS)[number]): boolean {
+		if (activeSegment === null) return false;
+		if (activeSegment === 'clamp_low') return key === 'cold';
+		if (activeSegment === 'clamp_high') return key === 'hot';
+		// Interpolating segments are named for the point they start from.
+		return activeSegment === key;
+	}
+
+	let modeSwitching = $state(false);
+	let modeError = $state<string | null>(null);
+	async function toggleHeatMode() {
+		if (modeSwitching) return;
+		modeSwitching = true;
+		modeError = null;
+		try {
+			const next = !followsCurve;
+			// An adjusted card is two backend jobs (the daily parent + the one-off for the
+			// next run). Flipping only one would leave the card claiming a mode the next
+			// run doesn't use, so both move together.
+			await onSetHeatMode?.(event.baseJob.jobId, next);
+			if (event.overrideJob) await onSetHeatMode?.(event.overrideJob.jobId, next);
+		} catch (e) {
+			modeError = e instanceof Error ? e.message : 'Failed to change heat mode';
+		} finally {
+			modeSwitching = false;
+		}
+	}
 </script>
 
 <div
@@ -245,6 +310,46 @@
 		<div class="min-w-0">
 			<div class="flex items-center gap-1.5">
 				<p class="truncate font-semibold text-slate-100" data-testid="event-title">{title}</p>
+				{#if followsCurve}
+					<!-- A real button: focus, Enter/Space and the right role come for free.
+					     Its icons are aria-hidden — a labelled button must not have its
+					     accessible name doubled by child icon labels, which is why these
+					     depart from the role="img" convention the recurring icon uses. -->
+					<button
+						type="button"
+						onclick={() => (detailOpen = !detailOpen)}
+						aria-expanded={detailOpen}
+						aria-controls={detailId}
+						aria-label="How the ambient target is chosen"
+						data-testid="event-dynamic-chip"
+						class="flex min-h-[24px] shrink-0 items-center gap-0.5 rounded px-1 text-sky-300/90 hover:bg-slate-700/60 hover:text-sky-200"
+					>
+						<svg
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							class="h-3.5 w-3.5"
+							aria-hidden="true"
+						>
+							<path d="M14 4v10.54a4 4 0 1 1-4 0V4a2 2 0 0 1 4 0Z" />
+						</svg>
+						<svg
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2"
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							class="h-3 w-3 transition-transform {detailOpen ? 'rotate-180' : ''}"
+							aria-hidden="true"
+						>
+							<path d="m6 9 6 6 6-6" />
+						</svg>
+					</button>
+				{/if}
 				{#if event.recurring}
 					<svg
 						viewBox="0 0 24 24"
@@ -288,6 +393,57 @@
 		{/if}
 	</div>
 
+	<!-- Explanation before controls, and outside the canAdjust gate so a Guest can still
+	     find out what "based on ambient temp" means on a card they can't change. -->
+	{#if followsCurve && detailOpen}
+		<div
+			id={detailId}
+			data-testid="event-dynamic-detail"
+			class="mt-3 rounded-lg border border-slate-700 bg-slate-900/40 p-3 text-xs text-slate-400"
+		>
+			<p data-testid="event-dynamic-explainer">
+				The water target follows the outdoor air temperature, and is chosen when this heat
+				starts — not now.
+			</p>
+
+			<p class="mt-2 font-medium text-slate-300" data-testid="event-dynamic-projection">
+				{projectionLabel}
+			</p>
+
+			<div class="mt-2 flex flex-wrap gap-1.5">
+				{#each CURVE_KEYS as key (key)}
+					{@const point = getCalibrationPoints()[key]}
+					<span
+						data-testid="event-dynamic-curve-point"
+						data-point={key}
+						data-active={pointIsActive(key)}
+						class="rounded px-1.5 py-0.5 {pointIsActive(key)
+							? 'bg-sky-500/20 text-sky-200'
+							: 'bg-slate-800 text-slate-500'}"
+						>{formatTemp(point.ambient_f)}° air → {formatTemp(point.water_target_f)}°F</span
+					>
+				{/each}
+			</div>
+
+			{#if savedTempF != null}
+				<p class="mt-2" data-testid="event-dynamic-steppers-note">
+					There's no ± temperature control because the curve sets the target. The saved
+					{formatTemp(savedTempF)}°F is used only if the air sensor is unavailable.
+				</p>
+			{/if}
+
+			{#if canConfigureCurve}
+				<p class="mt-2">
+					<a
+						href="{base}/setup"
+						data-testid="event-dynamic-setup-link"
+						class="text-sky-300 underline hover:text-sky-200">Adjust the curve in Setup</a
+					>
+				</p>
+			{/if}
+		</div>
+	{/if}
+
 	{#if canAdjust}
 		{#if editing}
 			<div class="mt-3 flex items-center gap-2">
@@ -320,7 +476,7 @@
 			<!-- Heat-to-target quick ± time / temp adjust — identical for one-time and
 			     recurring (card parity); clean recurring cards add Skip next / override
 			     management below. -->
-			<div class="mt-3 grid grid-cols-2 gap-2">
+			<div class="mt-3 grid gap-2 {tempAdjustable ? 'grid-cols-2' : 'grid-cols-1'}">
 				<div class="flex items-center justify-between rounded-lg bg-slate-900/50 px-2 py-1.5">
 					<button
 						type="button"
@@ -340,6 +496,7 @@
 						>+</button
 					>
 				</div>
+				{#if tempAdjustable}
 				<div class="flex items-center justify-between rounded-lg bg-slate-900/50 px-2 py-1.5">
 					<button
 						type="button"
@@ -361,6 +518,7 @@
 						>+</button
 					>
 				</div>
+				{/if}
 			</div>
 			<div class="mt-2 flex items-center gap-3 text-xs">
 				{#if rescheduleError}<span class="text-red-400">{rescheduleError}</span>{/if}
@@ -434,7 +592,7 @@
 						>
 					{/if}
 				{/if}
-				{#if isHeatToTarget && !getDynamicMode()}
+				{#if isHeatToTarget && !followsCurve}
 					<button
 						type="button"
 						onclick={startEdit}
@@ -450,6 +608,27 @@
 					class="ml-auto rounded-lg px-3 py-1 text-slate-400 hover:bg-red-500/10 hover:text-red-300"
 					>Remove</button
 				>
+			</div>
+		{/if}
+
+		<!-- One home for the mode switch, whichever control row rendered above — a fixed
+		     card has no disclosure to open it from, and duplicating it inside the
+		     expanded region would give ambient-matched cards two of the same button. -->
+		{#if isHeatToTarget && onSetHeatMode && !editing}
+			<div class="mt-2 text-xs">
+				<button
+					type="button"
+					onclick={toggleHeatMode}
+					disabled={modeSwitching}
+					data-testid="event-dynamic-mode-switch"
+					class="rounded-lg px-1 py-0.5 text-slate-400 underline decoration-slate-600 underline-offset-2 hover:text-slate-200 disabled:opacity-50"
+					>{modeSwitching
+						? 'Saving…'
+						: followsCurve
+							? 'Use a fixed temperature instead'
+							: 'Heat based on ambient temp instead'}</button
+				>
+				{#if modeError}<span class="ml-2 text-red-400">{modeError}</span>{/if}
 			</div>
 		{/if}
 	{/if}

--- a/frontend/src/lib/components/EventCard.test.ts
+++ b/frontend/src/lib/components/EventCard.test.ts
@@ -4,9 +4,26 @@ import EventCard from './EventCard.svelte';
 import { foldScheduledEvents, type LogicalEvent } from '$lib/scheduleUtils';
 import type { ScheduledJob } from '$lib/api';
 
-// Non-dynamic heat-to-target so the ± adjust branch renders.
+// The store mock is exhaustive by omission — anything the component imports and this
+// factory doesn't provide fails at IMPORT time, taking every test in the file with it.
+// Default: household default is "fixed", with a live projection available.
+const DEFAULT_PREVIEW = {
+	ambient_temp_f: 55.004,
+	computed_target_f: 102.67,
+	segment: 'cold',
+	clamped: false,
+	fallback: false
+};
+const DEFAULT_CALIBRATION_POINTS = {
+	cold: { ambient_f: 45, water_target_f: 104 },
+	comfort: { ambient_f: 60, water_target_f: 102 },
+	hot: { ambient_f: 75, water_target_f: 100.5 }
+};
 vi.mock('$lib/stores/heatTargetSettings.svelte', () => ({
-	getDynamicMode: vi.fn(() => false)
+	getDynamicMode: vi.fn(() => false),
+	getDynamicPreview: vi.fn(() => DEFAULT_PREVIEW),
+	getProjectedTargetF: vi.fn(() => DEFAULT_PREVIEW.computed_target_f),
+	getCalibrationPoints: vi.fn(() => DEFAULT_CALIBRATION_POINTS)
 }));
 
 // The registry is exercised by its own unit test; here we just spy on registration so
@@ -314,5 +331,208 @@ describe('EventCard overridden ("adjusted") card management', () => {
 		expect(screen.queryByTestId('event-make-permanent')).toBeNull();
 		expect(screen.getByTestId('event-oneoff-save')).toBeTruthy();
 		expect(screen.getByTestId('event-oneoff-discard')).toBeTruthy();
+	});
+});
+
+describe('EventCard ambient-matched (dynamic) heat mode', () => {
+	beforeEach(() => vi.clearAllMocks());
+
+	const dynamicOneOff = () => oneOffJob({ params: { target_temp_f: 102.25, dynamic: true } });
+	const fixedOneOff = () => oneOffJob({ params: { target_temp_f: 102.25, dynamic: false } });
+
+	it('titles an ambient-matched card by its mode, never by the stored number', () => {
+		render(EventCard, { props: { event: toEvent(dynamicOneOff()) } });
+
+		const title = screen.getByTestId('event-title').textContent ?? '';
+		expect(title).toBe('Heat based on ambient temp');
+		expect(title).not.toContain('102.25');
+	});
+
+	it('titles a fixed card by its target', () => {
+		render(EventCard, { props: { event: toEvent(fixedOneOff()) } });
+
+		expect(screen.getByTestId('event-title').textContent).toBe('Heat to 102.25°F');
+	});
+
+	it('shows the disclosure control only on an ambient-matched heat card', () => {
+		const { unmount } = render(EventCard, { props: { event: toEvent(dynamicOneOff()) } });
+		expect(screen.getByTestId('event-dynamic-chip')).toBeTruthy();
+		unmount();
+
+		render(EventCard, { props: { event: toEvent(fixedOneOff()) } });
+		expect(screen.queryByTestId('event-dynamic-chip')).toBeNull();
+	});
+
+	it('never shows the disclosure on a non-heat card', () => {
+		render(EventCard, {
+			props: { event: toEvent(oneOffJob({ action: 'pump-run', params: undefined })) }
+		});
+
+		expect(screen.queryByTestId('event-dynamic-chip')).toBeNull();
+	});
+
+	it('toggles the explanation, wiring aria-expanded to the region it controls', async () => {
+		render(EventCard, { props: { event: toEvent(dynamicOneOff()) } });
+
+		const chip = screen.getByTestId('event-dynamic-chip');
+		expect(chip.getAttribute('aria-expanded')).toBe('false');
+		expect(screen.queryByTestId('event-dynamic-detail')).toBeNull();
+
+		await fireEvent.click(chip);
+
+		expect(chip.getAttribute('aria-expanded')).toBe('true');
+		const detail = screen.getByTestId('event-dynamic-detail');
+		expect(chip.getAttribute('aria-controls')).toBe(detail.id);
+	});
+
+	// A real <button> is used precisely so the keyboard works without hand-rolled handlers.
+	it('opens from the keyboard', async () => {
+		render(EventCard, { props: { event: toEvent(dynamicOneOff()) } });
+
+		const chip = screen.getByTestId('event-dynamic-chip');
+		chip.focus();
+		await fireEvent.click(chip); // what Enter/Space dispatch on a native button
+
+		expect(screen.getByTestId('event-dynamic-detail')).toBeTruthy();
+	});
+
+	it('shows the live projection and highlights the active curve segment', async () => {
+		render(EventCard, { props: { event: toEvent(dynamicOneOff()) } });
+		await fireEvent.click(screen.getByTestId('event-dynamic-chip'));
+
+		expect(screen.getByTestId('event-dynamic-projection').textContent).toContain('≈102.67°F now');
+
+		const points = screen.getAllByTestId('event-dynamic-curve-point');
+		expect(points).toHaveLength(3);
+		const active = points.filter((p) => p.getAttribute('data-active') === 'true');
+		expect(active).toHaveLength(1);
+		expect(active[0].getAttribute('data-point')).toBe('cold');
+	});
+
+	it('is visible to a guest, who gets the explanation but no mode switch', async () => {
+		render(EventCard, { props: { event: toEvent(dynamicOneOff()), canAdjust: false } });
+
+		await fireEvent.click(screen.getByTestId('event-dynamic-chip'));
+		expect(screen.getByTestId('event-dynamic-explainer')).toBeTruthy();
+		expect(screen.queryByTestId('event-dynamic-mode-switch')).toBeNull();
+	});
+
+	it('switches an ambient-matched job back to a fixed temperature', async () => {
+		const onSetHeatMode = vi.fn().mockResolvedValue(undefined);
+		render(EventCard, {
+			props: { event: toEvent(dynamicOneOff()), canAdjust: true, onReschedule: vi.fn(), onSetHeatMode }
+		});
+
+		await fireEvent.click(screen.getByTestId('event-dynamic-chip'));
+		await fireEvent.click(screen.getByTestId('event-dynamic-mode-switch'));
+
+		await waitFor(() => expect(onSetHeatMode).toHaveBeenCalledTimes(1));
+		expect(onSetHeatMode).toHaveBeenCalledWith('job-1', false);
+	});
+
+	it('offers a fixed card the switch to ambient matching', async () => {
+		const onSetHeatMode = vi.fn().mockResolvedValue(undefined);
+		render(EventCard, {
+			props: { event: toEvent(fixedOneOff()), canAdjust: true, onReschedule: vi.fn(), onSetHeatMode }
+		});
+
+		await fireEvent.click(screen.getByTestId('event-dynamic-mode-switch'));
+
+		await waitFor(() => expect(onSetHeatMode).toHaveBeenCalledTimes(1));
+		expect(onSetHeatMode).toHaveBeenCalledWith('job-1', true);
+	});
+
+	// The time stepper vanishing in dynamic mode was a plain bug: when a heat starts has
+	// nothing to do with how its target is chosen.
+	it('keeps the time stepper but drops the temp stepper for an ambient-matched card', () => {
+		render(EventCard, {
+			props: { event: toEvent(dynamicOneOff()), canAdjust: true, onReschedule: vi.fn() }
+		});
+
+		expect(screen.getByTestId('event-oneoff-time')).toBeTruthy();
+		expect(screen.queryByTestId('event-oneoff-temp')).toBeNull();
+		expect(screen.getByRole('button', { name: '15 minutes later' })).toBeTruthy();
+		expect(screen.queryByRole('button', { name: 'a quarter degree warmer' })).toBeNull();
+	});
+
+	it('still saves a time-only nudge for an ambient-matched card', async () => {
+		const onReschedule = vi.fn().mockResolvedValue(undefined);
+		render(EventCard, {
+			props: { event: toEvent(dynamicOneOff()), canAdjust: true, onReschedule }
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: '15 minutes later' }));
+		await fireEvent.click(screen.getByTestId('event-oneoff-save'));
+
+		await waitFor(() => expect(onReschedule).toHaveBeenCalledTimes(1));
+		expect(onReschedule.mock.calls[0][2]).toBeUndefined(); // no temp argument
+	});
+
+	it('keeps both steppers on a fixed card', () => {
+		render(EventCard, {
+			props: { event: toEvent(fixedOneOff()), canAdjust: true, onReschedule: vi.fn() }
+		});
+
+		expect(screen.getByTestId('event-oneoff-time')).toBeTruthy();
+		expect(screen.getByTestId('event-oneoff-temp')).toBeTruthy();
+	});
+
+	it('explains why the temperature control is missing', async () => {
+		render(EventCard, {
+			props: { event: toEvent(dynamicOneOff()), canAdjust: true, onReschedule: vi.fn() }
+		});
+
+		await fireEvent.click(screen.getByTestId('event-dynamic-chip'));
+		expect(screen.getByTestId('event-dynamic-steppers-note').textContent).toContain('102.25');
+	});
+
+	it('links an owner to the curve setup', async () => {
+		render(EventCard, {
+			props: { event: toEvent(dynamicOneOff()), canAdjust: true, canConfigureCurve: true }
+		});
+
+		await fireEvent.click(screen.getByTestId('event-dynamic-chip'));
+		expect(screen.getByTestId('event-dynamic-setup-link')).toBeTruthy();
+	});
+
+	it('hides the curve setup link from a non-owner', async () => {
+		render(EventCard, { props: { event: toEvent(dynamicOneOff()), canAdjust: true } });
+
+		await fireEvent.click(screen.getByTestId('event-dynamic-chip'));
+		expect(screen.queryByTestId('event-dynamic-setup-link')).toBeNull();
+	});
+
+	// An adjusted card is TWO backend jobs. It reads its mode from the run about to fire,
+	// and a flip has to move both or the card claims a mode the next run doesn't use.
+	it('reads an adjusted card’s mode from the override, and flips both jobs together', async () => {
+		const onSetHeatMode = vi.fn().mockResolvedValue(undefined);
+		const event = toEvent(
+			recurringJob({ params: { target_temp_f: 102, dynamic: true } }),
+			overrideJob({ params: { target_temp_f: 102.25, override_of: 'rec-1', dynamic: true } })
+		);
+		render(EventCard, {
+			props: { event, canAdjust: true, onOverrideNext: vi.fn(), onSetHeatMode }
+		});
+
+		expect(screen.getByTestId('event-title').textContent).toBe('Heat based on ambient temp');
+
+		await fireEvent.click(screen.getByTestId('event-dynamic-mode-switch'));
+
+		await waitFor(() => expect(onSetHeatMode).toHaveBeenCalledTimes(2));
+		expect(onSetHeatMode).toHaveBeenNthCalledWith(1, 'rec-1', false);
+		expect(onSetHeatMode).toHaveBeenNthCalledWith(2, 'ovr-1', false);
+	});
+
+	it('describes an unsaved change with the fixed-form title, not the mode name', async () => {
+		const { registerPendingEdit } = await import('$lib/stores/pendingEdits.svelte');
+		render(EventCard, {
+			props: { event: toEvent(fixedOneOff()), canAdjust: true, onReschedule: vi.fn() }
+		});
+
+		await fireEvent.click(screen.getByRole('button', { name: '15 minutes later' }));
+
+		await waitFor(() => expect(registerPendingEdit).toHaveBeenCalled());
+		const registered = vi.mocked(registerPendingEdit).mock.calls.at(-1)![0];
+		expect(registered.describe()).toContain('Heat to');
 	});
 });

--- a/frontend/src/lib/components/SettingsPanel.svelte
+++ b/frontend/src/lib/components/SettingsPanel.svelte
@@ -353,9 +353,12 @@
 					<span class="text-slate-200 text-sm">Enable heat to target</span>
 				</label>
 
-				<!-- Target mode: Static vs Dynamic -->
+				<!-- Target mode. This is the DEFAULT for newly created schedules and for a
+				     manual "Heat now" — it does NOT reach back into existing scheduled jobs,
+				     each of which carries the mode it was created with. Without saying so the
+				     setting reads as broken ("I turned it on but my 6:30 heat didn't change"). -->
 				<fieldset class="ml-6 mt-1">
-					<legend class="text-slate-400 text-sm mb-2">Target mode</legend>
+					<legend class="text-slate-400 text-sm mb-2">Default target mode</legend>
 					<label class="flex items-center gap-2 cursor-pointer">
 						<input
 							type="radio"
@@ -378,8 +381,12 @@
 							disabled={savingTargetTemp}
 							class="w-4 h-4 border-slate-500 bg-slate-700 text-orange-500 focus:ring-orange-500"
 						/>
-						<span class="text-slate-300 text-sm">Dynamic (ambient-adjusted)</span>
+						<span class="text-slate-300 text-sm">Based on ambient temp</span>
 					</label>
+					<p class="text-slate-500 text-xs mt-2" data-testid="target-mode-default-note">
+						Applies to new schedules and to “Heat now”. Existing scheduled events keep the
+						mode they were created with — change one on its own card.
+					</p>
 				</fieldset>
 
 				{#if !localDynamicMode}

--- a/frontend/src/lib/scheduleUtils.test.ts
+++ b/frontend/src/lib/scheduleUtils.test.ts
@@ -9,12 +9,14 @@ import {
 	shiftHHMM,
 	formatClockHHMM,
 	jobTitle,
+	jobIsDynamic,
+	dynamicProjectionLabel,
 	resumeLabel,
 	jobClock,
 	baseSummary,
 	oneOffIso
 } from './scheduleUtils';
-import type { ScheduledJob } from './api';
+import type { DynamicTargetPreview, ScheduledJob } from './api';
 
 describe('scheduleUtils', () => {
 	describe('getTimezoneOffset', () => {
@@ -384,8 +386,19 @@ describe('scheduleUtils', () => {
 			expect(jobTitle(heatJob, false)).toBe('Heat to 102.25°F');
 		});
 
-		it('marks the target approximate in dynamic mode', () => {
-			expect(jobTitle(heatJob, true)).toBe('Heat to ~102.25°F');
+		it('names the mode, not a number, for an ambient-matched job', () => {
+			expect(jobTitle(heatJob, true)).toBe('Heat based on ambient temp');
+		});
+
+		// The old title decorated the STORED number with a tilde, but the tub will heat
+		// to whatever the curve picks — which could be a degree and a half away. Showing
+		// the stored number at all is the bug.
+		it('never shows the stored temperature for an ambient-matched job', () => {
+			expect(jobTitle(heatJob, true)).not.toContain('102.25');
+		});
+
+		it('defaults to the fixed title when no mode is passed', () => {
+			expect(jobTitle(heatJob)).toBe('Heat to 102.25°F');
 		});
 
 		it('uses the action label for non-target jobs', () => {
@@ -398,6 +411,78 @@ describe('scheduleUtils', () => {
 			expect(jobTitle({ ...heatJob, action: 'mystery-op', params: undefined }, false)).toBe(
 				'mystery-op'
 			);
+		});
+	});
+
+	describe('jobIsDynamic', () => {
+		const job = (dynamic?: boolean) =>
+			({
+				jobId: 'j1',
+				action: 'heat-to-target',
+				scheduledTime: '06:55',
+				createdAt: '2026-06-20T00:00:00Z',
+				recurring: true,
+				params: { target_temp_f: 102.25, ...(dynamic === undefined ? {} : { dynamic }) }
+			}) as ScheduledJob;
+
+		it('uses the job’s own flag when it has one', () => {
+			expect(jobIsDynamic(job(true), false)).toBe(true);
+			expect(jobIsDynamic(job(false), true)).toBe(false);
+		});
+
+		// Jobs created before per-job mode carry no flag; they keep inheriting the
+		// household default, which is what makes a migration script unnecessary.
+		it('falls back to the household default when the flag is absent', () => {
+			expect(jobIsDynamic(job(undefined), true)).toBe(true);
+			expect(jobIsDynamic(job(undefined), false)).toBe(false);
+		});
+
+		it('tolerates a job with no params at all', () => {
+			expect(jobIsDynamic({ ...job(undefined), params: undefined }, true)).toBe(true);
+		});
+	});
+
+	describe('dynamicProjectionLabel', () => {
+		const preview = (over: Partial<DynamicTargetPreview> = {}): DynamicTargetPreview =>
+			({
+				ambient_temp_f: 55.004,
+				computed_target_f: 102.67,
+				segment: 'cold',
+				clamped: false,
+				fallback: false,
+				...over
+			}) as DynamicTargetPreview;
+
+		it('reads out the air temperature and the target it implies', () => {
+			expect(dynamicProjectionLabel(preview(), 102.25)).toBe('air 55° → ≈102.67°F now');
+		});
+
+		it('explains a clamped projection in plain words', () => {
+			const label = dynamicProjectionLabel(
+				preview({ ambient_temp_f: 38, computed_target_f: 104, segment: 'clamp_low', clamped: true }),
+				102.25
+			);
+			expect(label).toBe('air 38° → ≈104°F now (below the curve — held at the cold setting)');
+		});
+
+		it('explains a high clamp too', () => {
+			const label = dynamicProjectionLabel(
+				preview({ ambient_temp_f: 90, computed_target_f: 100.5, segment: 'clamp_high', clamped: true }),
+				102.25
+			);
+			expect(label).toContain('above the curve — held at the hot setting');
+		});
+
+		it('names the saved temperature as the sensor-offline fallback', () => {
+			const label = dynamicProjectionLabel(
+				preview({ ambient_temp_f: null, fallback: true, fallback_reason: 'ambient_sensor_unavailable' }),
+				102.25
+			);
+			expect(label).toBe('Air sensor unavailable — this event’s saved 102.25°F will be used');
+		});
+
+		it('says so plainly when there is no projection', () => {
+			expect(dynamicProjectionLabel(null, 102.25)).toBe('Projection unavailable');
 		});
 	});
 

--- a/frontend/src/lib/scheduleUtils.ts
+++ b/frontend/src/lib/scheduleUtils.ts
@@ -1,4 +1,4 @@
-import type { ScheduledJob } from './api';
+import type { DynamicTargetPreview, ScheduledJob } from './api';
 
 /**
  * Get the local timezone offset in ISO 8601 format (e.g., "+05:30", "-08:00")
@@ -332,15 +332,56 @@ const ACTION_LABELS: Record<string, string> = {
 };
 
 /**
- * "Heat to 102.25°F" (with `tilde` for dynamic-mode approximate targets), else the
- * plain action label. The caller passes the dynamic-mode flag — this module must
- * stay free of store imports.
+ * Whether a job heats to an ambient-derived target rather than its stored number.
+ *
+ * A job stamped at creation carries its own flag. A job predating per-job mode carries
+ * none and keeps inheriting the household default — which is what lets per-job mode ship
+ * with no migration. The default is passed in: this module must stay free of store imports.
  */
-export function jobTitle(job: ScheduledJob, tilde: boolean): string {
+export function jobIsDynamic(job: ScheduledJob, defaultDynamic: boolean): boolean {
+	return job.params?.dynamic ?? defaultDynamic;
+}
+
+/**
+ * "Heat to 102.25°F", or "Heat based on ambient temp" for a job that follows the curve.
+ *
+ * The mode goes in the title in plain words rather than a badge (badges mark exceptions
+ * only — review F4), and an ambient-matched card shows NO number: the stored temp is
+ * only a sensor-offline fallback, and printing it implies a target the tub won't use.
+ */
+export function jobTitle(job: ScheduledJob, dynamic = false): string {
 	if (job.action === 'heat-to-target' && job.params?.target_temp_f != null) {
-		return `Heat to ${tilde ? '~' : ''}${formatTemp(job.params.target_temp_f)}°F`;
+		return dynamic ? 'Heat based on ambient temp' : `Heat to ${formatTemp(job.params.target_temp_f)}°F`;
 	}
 	return ACTION_LABELS[job.action] ?? job.action;
+}
+
+/**
+ * The live projection line for an expanded ambient-matched card: what the curve would
+ * pick right now, framed as "now" because a 6:30 AM job will use 6:30 AM's air.
+ *
+ * @param preview The current projection, or null when there is none
+ * @param staticFallbackF The job's saved temp — what actually gets used if the sensor is down
+ */
+export function dynamicProjectionLabel(
+	preview: DynamicTargetPreview | null | undefined,
+	staticFallbackF: number | null | undefined
+): string {
+	if (!preview) return 'Projection unavailable';
+
+	if (preview.fallback) {
+		const saved = staticFallbackF != null ? `saved ${formatTemp(staticFallbackF)}°F` : 'saved temperature';
+		return `Air sensor unavailable — this event’s ${saved} will be used`;
+	}
+
+	const air = preview.ambient_temp_f != null ? Math.round(preview.ambient_temp_f) : '—';
+	const line = `air ${air}° → ≈${formatTemp(preview.computed_target_f)}°F now`;
+
+	// A clamp means the air is off the ends of the curve, so the target has stopped
+	// tracking it — say that, or the number looks stuck.
+	if (preview.segment === 'clamp_low') return `${line} (below the curve — held at the cold setting)`;
+	if (preview.segment === 'clamp_high') return `${line} (above the curve — held at the hot setting)`;
+	return line;
 }
 
 /**

--- a/frontend/src/lib/stores/heatTargetSettings.svelte.ts
+++ b/frontend/src/lib/stores/heatTargetSettings.svelte.ts
@@ -1,4 +1,11 @@
-import { api, type CalibrationPoints, type HeatTargetSettings, type HealthResponse, type LastStallEvent } from '$lib/api';
+import {
+	api,
+	type CalibrationPoints,
+	type DynamicTargetPreview,
+	type HeatTargetSettings,
+	type HealthResponse,
+	type LastStallEvent
+} from '$lib/api';
 
 /**
  * Store for shared heat-target settings from the backend.
@@ -36,6 +43,7 @@ let stallGracePeriodMinutes = $state(DEFAULT_STALL_GRACE_PERIOD_MINUTES);
 let stallTimeoutMinutes = $state(DEFAULT_STALL_TIMEOUT_MINUTES);
 let dynamicMode = $state(DEFAULT_DYNAMIC_MODE);
 let calibrationPoints = $state<CalibrationPoints>(DEFAULT_CALIBRATION_POINTS);
+let dynamicPreview = $state<DynamicTargetPreview | null>(null);
 let lastStallEvent = $state<LastStallEvent | null>(null);
 let isLoading = $state(false);
 let error = $state<string | null>(null);
@@ -57,6 +65,9 @@ export function initFromHealthResponse(response: HealthResponse): void {
 			response.heatTargetSettings.stall_timeout_minutes ?? DEFAULT_STALL_TIMEOUT_MINUTES;
 		dynamicMode = response.heatTargetSettings.dynamic_mode ?? DEFAULT_DYNAMIC_MODE;
 		calibrationPoints = response.heatTargetSettings.calibration_points ?? DEFAULT_CALIBRATION_POINTS;
+		// Absent for an anonymous caller and null when heat-to-target is off — either
+		// way there's no projection to show, so don't keep a stale one on screen.
+		dynamicPreview = response.heatTargetSettings.dynamic_preview ?? null;
 	} else {
 		// Reset to defaults when backend doesn't provide settings
 		enabled = DEFAULT_ENABLED;
@@ -67,6 +78,7 @@ export function initFromHealthResponse(response: HealthResponse): void {
 		stallTimeoutMinutes = DEFAULT_STALL_TIMEOUT_MINUTES;
 		dynamicMode = DEFAULT_DYNAMIC_MODE;
 		calibrationPoints = DEFAULT_CALIBRATION_POINTS;
+		dynamicPreview = null;
 	}
 	lastStallEvent = response.lastStallEvent ?? null;
 	initialized = true;
@@ -279,10 +291,30 @@ export function getLastStallEvent(): LastStallEvent | null {
 }
 
 /**
- * Check if dynamic target mode is enabled.
+ * The household DEFAULT heat mode: stamped onto newly created jobs, and the mode a
+ * manual "Heat now" uses. It is NOT retroactive — an existing job carries its own
+ * `params.dynamic` (see jobIsDynamic in scheduleUtils).
  */
 export function getDynamicMode(): boolean {
 	return dynamicMode;
+}
+
+/**
+ * What the ambient curve would pick right now, or null when there's no projection
+ * (heat-to-target off, or the caller wasn't authenticated for the health response).
+ */
+export function getDynamicPreview(): DynamicTargetPreview | null {
+	return dynamicPreview;
+}
+
+/**
+ * The projected target in °F, or null when there isn't a real one — no projection at
+ * all, or the ambient sensor is down (in which case a job's own saved temp is what
+ * will actually be used, so callers must not show the fallback number as a projection).
+ */
+export function getProjectedTargetF(): number | null {
+	if (dynamicPreview === null || dynamicPreview.fallback) return null;
+	return dynamicPreview.computed_target_f;
 }
 
 /**

--- a/frontend/src/lib/stores/heatTargetSettings.test.ts
+++ b/frontend/src/lib/stores/heatTargetSettings.test.ts
@@ -25,7 +25,9 @@ import {
 	getStallTimeoutMinutes,
 	getLastStallEvent,
 	getDynamicMode,
-	getCalibrationPoints
+	getCalibrationPoints,
+	getDynamicPreview,
+	getProjectedTargetF
 } from './heatTargetSettings.svelte';
 import { api } from '$lib/api';
 
@@ -395,6 +397,112 @@ describe('heatTargetSettings store', () => {
 			});
 
 			expect(getHeatButtonTooltip()).toBe('Heat to dynamic target based on ambient temperature');
+		});
+
+		it('hydrates the live curve projection from the health response', () => {
+			initFromHealthResponse({
+				status: 'ok',
+				ifttt_mode: 'stub',
+				equipmentStatus: {
+					heater: { on: false, lastChangedAt: null },
+					pump: { on: false, lastChangedAt: null }
+				},
+				heatTargetSettings: {
+					enabled: true,
+					target_temp_f: 102,
+					timezone: 'America/Los_Angeles',
+					dynamic_preview: {
+						ambient_temp_f: 55.004,
+						computed_target_f: 102.67,
+						segment: 'cold',
+						clamped: false,
+						fallback: false
+					}
+				}
+			});
+
+			expect(getDynamicPreview()?.segment).toBe('cold');
+			expect(getProjectedTargetF()).toBe(102.67);
+		});
+
+		it('reports no projection when the response omits one', () => {
+			initFromHealthResponse({
+				status: 'ok',
+				ifttt_mode: 'stub',
+				equipmentStatus: {
+					heater: { on: false, lastChangedAt: null },
+					pump: { on: false, lastChangedAt: null }
+				},
+				heatTargetSettings: {
+					enabled: true,
+					target_temp_f: 102,
+					timezone: 'America/Los_Angeles'
+				}
+			});
+
+			expect(getDynamicPreview()).toBeNull();
+			expect(getProjectedTargetF()).toBeNull();
+		});
+
+		it('clears a stale projection when settings disappear from the response', () => {
+			initFromHealthResponse({
+				status: 'ok',
+				ifttt_mode: 'stub',
+				equipmentStatus: {
+					heater: { on: false, lastChangedAt: null },
+					pump: { on: false, lastChangedAt: null }
+				},
+				heatTargetSettings: {
+					enabled: true,
+					target_temp_f: 102,
+					timezone: 'America/Los_Angeles',
+					dynamic_preview: {
+						ambient_temp_f: 55,
+						computed_target_f: 102.67,
+						segment: 'cold',
+						clamped: false,
+						fallback: false
+					}
+				}
+			});
+			initFromHealthResponse({
+				status: 'ok',
+				ifttt_mode: 'stub',
+				equipmentStatus: {
+					heater: { on: false, lastChangedAt: null },
+					pump: { on: false, lastChangedAt: null }
+				}
+			});
+
+			expect(getDynamicPreview()).toBeNull();
+		});
+
+		// A sensor-offline projection has no real number to show; the card falls back to
+		// the job's saved temp, so callers must not read computed_target_f as a target.
+		it('reports no projected target when the ambient sensor is down', () => {
+			initFromHealthResponse({
+				status: 'ok',
+				ifttt_mode: 'stub',
+				equipmentStatus: {
+					heater: { on: false, lastChangedAt: null },
+					pump: { on: false, lastChangedAt: null }
+				},
+				heatTargetSettings: {
+					enabled: true,
+					target_temp_f: 102,
+					timezone: 'America/Los_Angeles',
+					dynamic_preview: {
+						ambient_temp_f: null,
+						computed_target_f: 102,
+						clamped: false,
+						fallback: true,
+						fallback_reason: 'ambient_sensor_unavailable'
+					}
+				}
+			});
+
+			expect(getDynamicPreview()?.fallback).toBe(true);
+			expect(getProjectedTargetF()).toBeNull();
 		});
 
 		it('updates dynamic mode via updateSettings', async () => {

--- a/frontend/src/routes/(v2)/+page.svelte
+++ b/frontend/src/routes/(v2)/+page.svelte
@@ -7,7 +7,7 @@
 	import TemperaturePanel from '$lib/components/TemperaturePanel.svelte';
 	import EventCard from '$lib/components/EventCard.svelte';
 	import { api, type TargetTemperatureState, type ScheduledJob } from '$lib/api';
-	import { canControl, canSchedule, canTuneTarget } from '$lib/roles';
+	import { canControl, canSchedule, canTuneTarget, canConfigure } from '$lib/roles';
 	import { foldScheduledEvents, type LogicalEvent } from '$lib/scheduleUtils';
 	import { skipEvent, cancelEvent, makePermanentEvent } from '$lib/scheduleActions';
 	import {
@@ -93,6 +93,7 @@
 	let scheduledJobs = $state<ScheduledJob[]>([]);
 	const events = $derived(foldScheduledEvents(scheduledJobs));
 	const canSched = $derived(canSchedule(data.user?.role));
+	const canConfigureCurve = $derived(canConfigure(data.user?.role));
 
 	async function reloadJobs() {
 		try {
@@ -116,6 +117,12 @@
 	}
 	async function handleRescheduleOneOff(jobId: string, scheduledTime: string, tempF?: number) {
 		await api.rescheduleOneOff(jobId, scheduledTime, tempF);
+		await reloadJobs();
+	}
+	// Flips the job itself, not the household default — Home's dial and Heat button
+	// still follow the global setting.
+	async function handleSetHeatMode(jobId: string, dynamic: boolean) {
+		await api.setScheduledJobHeatMode(jobId, dynamic);
 		await reloadJobs();
 	}
 
@@ -353,6 +360,8 @@
 					<EventCard
 						{event}
 						canAdjust={canSched}
+						{canConfigureCurve}
+						onSetHeatMode={handleSetHeatMode}
 						onOverrideNext={handleOverrideNext}
 						onReschedule={handleRescheduleOneOff}
 						onSkip={handleSkip}

--- a/frontend/src/routes/(v2)/schedule/+page.svelte
+++ b/frontend/src/routes/(v2)/schedule/+page.svelte
@@ -1,19 +1,21 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { api, type ScheduledJob } from '$lib/api';
-	import { canSchedule } from '$lib/roles';
+	import { canSchedule, canConfigure } from '$lib/roles';
 	import { foldScheduledEvents, getTimezoneOffset, type LogicalEvent } from '$lib/scheduleUtils';
 	import { skipEvent, cancelEvent, makePermanentEvent } from '$lib/scheduleActions';
 	import { fetchStatus } from '$lib/stores/equipmentStatus.svelte';
 	import {
 		getTargetTempF,
 		getScheduleMode,
+		getDynamicMode,
 		getTimezone as getConfiguredTimezone
 	} from '$lib/stores/heatTargetSettings.svelte';
 	import EventCard from '$lib/components/EventCard.svelte';
 
 	let { data } = $props();
 	const allowed = $derived(canSchedule(data.user?.role));
+	const owner = $derived(canConfigure(data.user?.role));
 
 	let jobs = $state<ScheduledJob[]>([]);
 	let error = $state<string | null>(null);
@@ -96,11 +98,18 @@
 		await api.rescheduleRecurring(jobId, time, tempF);
 		await loadJobs();
 	}
+	// Switch ONE job between a fixed temperature and the ambient curve; the household
+	// default in Setup is untouched.
+	async function handleSetHeatMode(jobId: string, dynamic: boolean) {
+		await api.setScheduledJobHeatMode(jobId, dynamic);
+		await loadJobs();
+	}
 
 	// ---- Add-heating sheet ----
 	let showAdd = $state(false);
 	let addAction = $state<'heat-to-target' | 'pump-run'>('heat-to-target');
 	let addTemp = $state(103);
+	let addDynamic = $state(false);
 	let addTime = $state('06:30');
 	let addRecurring = $state(true);
 	let addDate = $state('');
@@ -112,6 +121,8 @@
 	function openAdd() {
 		addAction = 'heat-to-target';
 		addTemp = getTargetTempF();
+		// Seeded from the household default; the job keeps whatever it's created with.
+		addDynamic = getDynamicMode();
 		addTime = '06:30';
 		addRecurring = true;
 		const tomorrow = new Date();
@@ -133,7 +144,10 @@
 		adding = true;
 		addError = null;
 		try {
-			const params = addAction === 'heat-to-target' ? { target_temp_f: addTemp } : undefined;
+			const params =
+				addAction === 'heat-to-target'
+					? { target_temp_f: addTemp, dynamic: addDynamic }
+					: undefined;
 			if (addRecurring) {
 				await api.scheduleJob(addAction, addTime, true, params, getConfiguredTimezone());
 			} else {
@@ -192,8 +206,31 @@
 				</div>
 
 				{#if addAction === 'heat-to-target'}
+					<!-- The mode is stamped onto the job now, so it keeps this setting even if
+					     the household default changes later. -->
+					<div class="grid grid-cols-2 gap-2">
+						<button
+							type="button"
+							onclick={() => (addDynamic = false)}
+							data-testid="add-mode-fixed"
+							aria-pressed={!addDynamic}
+							class="rounded-lg border px-3 py-2 text-sm {!addDynamic
+								? 'border-orange-500 bg-orange-500/10 text-orange-300'
+								: 'border-slate-600 text-slate-300'}">Fixed temperature</button
+						>
+						<button
+							type="button"
+							onclick={() => (addDynamic = true)}
+							data-testid="add-mode-dynamic"
+							aria-pressed={addDynamic}
+							class="rounded-lg border px-3 py-2 text-sm {addDynamic
+								? 'border-sky-500 bg-sky-500/10 text-sky-300'
+								: 'border-slate-600 text-slate-300'}">Based on ambient temp</button
+						>
+					</div>
+
 					<label class="flex items-center justify-between text-sm text-slate-300">
-						Heat to
+						{addDynamic ? 'If the air sensor is down, heat to' : 'Heat to'}
 						<span class="flex items-center gap-1">
 							<input
 								type="number"
@@ -277,6 +314,8 @@
 					<EventCard
 						{event}
 						canAdjust={allowed}
+						canConfigureCurve={owner}
+						onSetHeatMode={handleSetHeatMode}
 						onSkip={handleSkip}
 						onUnskip={handleUnskip}
 						onCancel={handleCancel}


### PR DESCRIPTION
## What

The dynamic ("heat to a target derived from outdoor air") setting was a single global switch resolved at heat-start time, so flipping it retroactively changed what every already-scheduled job would do. A card couldn't report its own mode because it didn't have one — and in dynamic mode it rendered `Heat to ~102.25°F`, a tilde decorating the job's *stored* number, which is not what the tub heats to.

The mode is now a property of each job (`params.dynamic`), stamped at creation. The Setup toggle becomes the default for **new** schedules and for manual "Heat now"; it no longer reaches back into existing jobs. Jobs created before this change carry no flag and keep inheriting the global default, so there's no migration.

## Backend

- `TargetTemperatureService::start()` takes a tri-state `?bool $dynamic`. The ambient read and curve calculation collapse into one `computeCurveTarget()` call site, shared with the new public `previewDynamicTarget()` — so the number a card shows and the number a heat starts with can't drift apart.
- `dynamic_target_info` records `source: per_job | global_default`.
- `ScheduleController` stamps the mode on `create()` and carries it through `overrideNext()`, which rebuilds params from scratch.
- New `PUT /api/schedule/{id}/heat-mode`.
- `DtdtService` carries the mode onto the precision one-off and into `startImmediately()`, and now computes ready-by lead time against the **projected** target. Previously it projected cooling from the static temp while the heat later aimed at the ambient-derived one, so a cold morning left the tub late to its ready-by time. That bug predates this work; per-job mode makes it reachable more often.
- `/api/health` attaches `dynamic_preview` only for an authenticated caller — it carries a live outdoor-air reading and a sensor-offline signal.

## Frontend

- Cards read **"Heat based on ambient temp"** — the mode in plain words, and no stored number, since that number is only the sensor-offline fallback.
- A thermometer/chevron disclosure (a real `<button>`, so focus, Enter/Space and the right role come for free) expands: one sentence of explanation, the live projection framed as "now", the three curve points with the active segment lit, and why there's no ± temperature control. Visible to Guests; the mode switch is write-roles only.
- **Split the stepper gate.** The *time* stepper no longer disappears in dynamic mode — when a heat starts has nothing to do with how its target is chosen. That was a plain bug.
- The add-heating sheet gains a Fixed / Based-on-ambient choice, seeded from the household default.
- Setup's toggle is relabelled "Default target mode" with a note that existing events keep the mode they were created with — otherwise it reads as broken.

## Two deliberate departures from the plan

Both to avoid blanking the projection on exactly the cards that need it:

1. `previewDynamicTarget()` is gated on **neither** `dynamic_mode` nor `enabled`. The plan had it short-circuit when the global dynamic mode was off, but that's the intended setup (household default fixed, individual jobs ambient-matched) — the projection would always be null. Scheduled heat-to-target jobs also outlive the "Enable heat to target" toggle. The cost is one ESP32 reading, the same file `/api/temperature` already polls.
2. The mode switch lives with the card's other controls rather than inside the disclosure, since a fixed card has no disclosure to open it from and needs somewhere to turn ambient matching **on**.

Also, an adjusted card is two backend jobs (daily parent + one-off for the next run); it reads its mode from the run about to fire, and a flip moves both, so it can't claim a mode the next run doesn't use.

## Knowingly deferred

- v1's `SchedulePanel` builds its own title inline and keeps the misleading tilde. v1 is slated for deletion after UAT.
- `/api/health` has no route-level PHPUnit harness (`ApiTest` calls the controller directly, bypassing the router and auth gate), so the anonymous-caller behaviour is covered only in e2e.

## Testing

`./scripts/test.sh` all green: **1033** backend, **317** frontend unit, **58** ESP32, **145** e2e.

New coverage includes the three from-scratch params rebuilds that would silently drop the field (`overrideNext`, `handleWakeUp`, `startImmediately`), a contract test that the projection shifts by exactly the ambient sensor's calibration offset, an equivalence test that the preview matches what `start()` writes, and an e2e assertion that an unauthenticated `/api/health` carries no `dynamic_preview`.

Also verified by hand that `cron-runner.sh`'s flat-params regex still extracts a valid body with the new field — a comment now records that constraint (`[^}]*` stops at the first closing brace, so params must stay flat).

The two e2e specs pin the calibration curve themselves rather than trusting `global-setup`, which resets once per run and not between specs — `heat-target-settings.spec.ts` persists its own curve, which made the projection order-dependent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)